### PR TITLE
Starte wöchentliches Mario Kart 64 Event

### DIFF
--- a/src/contexts/EventContext.tsx
+++ b/src/contexts/EventContext.tsx
@@ -12,12 +12,41 @@ const mockEvents: GameEvent[] = [
     category: 'Speedrun',
     startDate: new Date('2024-02-01'),
     endDate: new Date('2024-02-15'),
-    isActive: true,
+    isActive: false,
     participants: 42,
     maxParticipants: 100,
     rules: ['PAL-Version', 'Keine Glitches', 'Video-Beweis erforderlich'],
     prizes: ['1. Platz: Goldene Cartridge', '2. Platz: Silberne Cartridge', '3. Platz: Bronze Cartridge'],
     region: 'PAL'
+  },
+  {
+    id: '2',
+    title: 'Mario Kart 64 - Luigi\'s Raceway Live Event',
+    description: 'Eine Woche lang Luigi\'s Raceway Zeitrennen! Zeigt eure beste Zeit auf der klassischen Strecke und kämpft um die Krone!',
+    game: 'Mario Kart 64',
+    category: 'Time Trial',
+    startDate: new Date('2025-07-20'),
+    endDate: new Date('2025-07-27'),
+    isActive: true,
+    participants: 0,
+    maxParticipants: 150,
+    rules: [
+      'Luigi\'s Raceway - 3 Runden',
+      'PAL oder NTSC Version erlaubt',
+      'Keine Glitches oder Shortcuts',
+      'Screenshot oder Video als Beweis erforderlich',
+      'Beste Zeit pro Spieler zählt',
+      'Startzeit: Sonntag 20.07.2025',
+      'Endzeit: Sonntag 27.07.2025 23:59 UTC'
+    ],
+    prizes: [
+      '🥇 1. Platz: Goldener Luigi Trophy + 200 XP + Luigi\'s Raceway Master Badge',
+      '🥈 2. Platz: Silberner Luigi Trophy + 150 XP + Speed Demon Badge', 
+      '🥉 3. Platz: Bronzener Luigi Trophy + 100 XP + Time Trial Expert Badge',
+      '🏆 Top 10: Luigi\'s Raceway Veteran Badge + 50 XP',
+      '🎮 Alle Teilnehmer: Luigi\'s Raceway Participant Badge + 25 XP'
+    ],
+    region: 'BOTH'
   }
 ]
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -25,7 +25,7 @@ interface NewsItem {
   title: string
   content: string
   date: Date
-  type: 'event_winner' | 'n64_history' | 'community_news'
+  type: 'event_winner' | 'n64_history' | 'community_news' | 'event_announcement'
 }
 
 const HomePage: React.FC = () => {
@@ -47,20 +47,27 @@ const HomePage: React.FC = () => {
   const newsItems: NewsItem[] = [
     {
       id: '1',
+      title: '🏁 NEUES LIVE EVENT: Luigi\'s Raceway Zeitrennen!',
+      content: 'Eine ganze Woche lang Luigi\'s Raceway! Zeigt eure beste Zeit auf der klassischen Mario Kart 64 Strecke. Event läuft bis 27.07.2025 - Jetzt teilnehmen!',
+      date: new Date(),
+      type: 'event_announcement'
+    },
+    {
+      id: '2',
       title: 'Event Winner: Mario Kart 64 Challenge',
       content: 'Spieler "SpeedDemon64" hat das Mario Kart 64 Speedrun Event mit einer Zeit von 1:47:32 gewonnen!',
       date: new Date(),
       type: 'event_winner'
     },
     {
-      id: '2',
+      id: '3',
       title: 'Heute in der N64 Geschichte',
       content: 'Vor 27 Jahren (1996) wurde das Nintendo 64 in Japan veröffentlicht. Das erste Spiel war Super Mario 64!',
       date: new Date(),
       type: 'n64_history'
     },
     {
-      id: '3',
+      id: '4',
       title: 'Community Update',
       content: 'Neue Speedrun-Kategorien für GoldenEye 007 wurden hinzugefügt. Jetzt mit Agent, Secret Agent und 00 Agent Modi!',
       date: new Date(),


### PR DESCRIPTION
Add a new Mario Kart 64 Luigi's Raceway live event and its announcement to the homepage.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-6e2cfdce-13db-42f5-ad27-c498d4625aa9) · [Cursor](https://cursor.com/background-agent?bcId=bc-6e2cfdce-13db-42f5-ad27-c498d4625aa9)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)