### PR TITLE
Fix homescreen card and remove messages

### DIFF
--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -15,6 +15,9 @@ interface NewsCardProps {
 }
 
 const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
+  // Debug logging
+  console.log('NewsCard rendering:', { title: newsItem.title, content: newsItem.content, index })
+  
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString('de-DE', {
       hour: '2-digit',
@@ -71,10 +74,10 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
       <div className="swipeable-card-content">
         <div className="swipeable-item p-3 h-full flex flex-col">
           <div className="flex-1">
-            <h4 className="text-sm font-semibold text-slate-100 mb-2 line-clamp-2">
+            <h4 className="text-sm font-semibold text-slate-100 mb-2" style={{ color: '#f1f5f9', fontSize: '14px' }}>
               {newsItem.title}
             </h4>
-            <p className="text-xs text-slate-300 mb-3 line-clamp-4">
+            <p className="text-xs text-slate-300 mb-3" style={{ color: '#cbd5e1', fontSize: '12px' }}>
               {newsItem.content}
             </p>
           </div>

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { TrendingUp } from 'lucide-react'
 
 interface NewsItem {
@@ -15,36 +15,11 @@ interface NewsCardProps {
 }
 
 const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
-  const [showMessage, setShowMessage] = useState(false)
-  const [messageText, setMessageText] = useState('')
-
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString('de-DE', {
       hour: '2-digit',
       minute: '2-digit'
     })
-  }
-
-  const handleCardClick = () => {
-    const messages = [
-      '📰 News gelesen!',
-      '✨ Interessant!',
-      '🎮 N64 News!',
-      '📱 Artikel geöffnet!',
-      '🎯 News entdeckt!',
-      '⭐ Mehr erfahren!',
-      '🔥 Hot News!',
-      '💫 News geladen!'
-    ]
-    
-    const randomMessage = messages[Math.floor(Math.random() * messages.length)]
-    setMessageText(randomMessage)
-    setShowMessage(true)
-    
-    // Hide message after 2 seconds
-    setTimeout(() => {
-      setShowMessage(false)
-    }, 2000)
   }
 
   const getTypeColor = (type: string) => {
@@ -78,10 +53,7 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
   }
 
   return (
-    <div 
-      className="swipeable-card bg-gradient-to-br from-blue-600/10 to-purple-600/10 border-l-4 border-blue-400 relative cursor-pointer hover:shadow-xl transition-all duration-300 hover:scale-105"
-      onClick={handleCardClick}
-    >
+    <div className="swipeable-card bg-gradient-to-br from-blue-600/10 to-purple-600/10 border-l-4 border-blue-400 relative">
       <div className="swipeable-card-header">
         <div className="flex items-center gap-2">
           <TrendingUp className="w-5 h-5 text-blue-400" />
@@ -108,19 +80,10 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
           </div>
           <div className="flex items-center justify-between text-xs text-slate-400">
             <span>{formatTime(newsItem.date)}</span>
-            <span className="text-blue-400">Klicken für mehr</span>
+            <span className="text-blue-400">News Details</span>
           </div>
         </div>
       </div>
-
-      {/* Click Message Overlay */}
-      {showMessage && (
-        <div className="absolute inset-0 bg-black/70 flex items-center justify-center z-10 transition-opacity duration-300">
-          <div className="bg-slate-800/90 border border-slate-600 rounded-lg px-4 py-3 text-center backdrop-blur-sm">
-            <p className="text-slate-100 text-sm font-medium">{messageText}</p>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -15,9 +15,6 @@ interface NewsCardProps {
 }
 
 const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
-  // Debug logging
-  console.log('NewsCard rendering:', { title: newsItem.title, content: newsItem.content, index })
-  
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString('de-DE', {
       hour: '2-digit',
@@ -72,16 +69,16 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index }) => {
       </div>
       
       <div className="swipeable-card-content">
-        <div className="swipeable-item p-3 h-full flex flex-col">
+        <div className="p-3 h-full flex flex-col">
           <div className="flex-1">
-            <h4 className="text-sm font-semibold text-slate-100 mb-2" style={{ color: '#f1f5f9', fontSize: '14px' }}>
+            <h4 className="text-sm sm:text-base font-semibold text-slate-100 mb-2 leading-tight">
               {newsItem.title}
             </h4>
-            <p className="text-xs text-slate-300 mb-3" style={{ color: '#cbd5e1', fontSize: '12px' }}>
+            <p className="text-xs sm:text-sm text-slate-300 mb-3 leading-relaxed">
               {newsItem.content}
             </p>
           </div>
-          <div className="flex items-center justify-between text-xs text-slate-400">
+          <div className="flex items-center justify-between text-xs text-slate-400 mt-auto">
             <span>{formatTime(newsItem.date)}</span>
             <span className="text-blue-400">News Details</span>
           </div>

--- a/src/components/SwipeableCard.tsx
+++ b/src/components/SwipeableCard.tsx
@@ -130,7 +130,7 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
           {displayItems.map((item, index) => (
             <div 
               key={index} 
-              className="flex-shrink-0 h-full p-3 overflow-hidden"
+              className="flex-shrink-0 h-full p-2 sm:p-3 overflow-hidden"
               style={{ width: `${100 / displayItems.length}%` }}
             >
               {renderItem(item, index)}

--- a/src/components/SwipeableCard.tsx
+++ b/src/components/SwipeableCard.tsx
@@ -21,8 +21,6 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isTransitioning, setIsTransitioning] = useState(false)
-  const [showMessage, setShowMessage] = useState(false)
-  const [messageText, setMessageText] = useState('')
   const touchStartX = useRef<number>(0)
   const touchEndX = useRef<number>(0)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -30,47 +28,10 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
   const maxItems = Math.min(items.length, 10) // Limit to 10 items as requested
   const displayItems = items.slice(0, maxItems)
 
-  const showSwipeMessage = (direction: 'next' | 'prev') => {
-    const messages = {
-      next: [
-        '✨ Nächste Karte wird geladen...',
-        '🎮 Hier kommt die nächste!',
-        '🚀 Weiter geht\'s!',
-        '📱 Swipe erfolgreich!',
-        '🎯 Neue Inhalte entdecken!',
-        '⭐ Mehr davon!',
-        '🔥 Keep swiping!',
-        '💫 Nächster Inhalt!'
-      ],
-      prev: [
-        '⬅️ Zurück zur vorherigen Karte',
-        '🔄 Rückwärts navigiert!',
-        '📍 Vorherige Karte geladen',
-        '↩️ Zurück geswipet!',
-        '🎮 Rückwärts!',
-        '⏪ Previous content!',
-        '🔙 Zurück!',
-        '📱 Rückwärts-Swipe!'
-      ]
-    }
-    
-    const messageArray = messages[direction]
-    const randomMessage = messageArray[Math.floor(Math.random() * messageArray.length)]
-    
-    setMessageText(randomMessage)
-    setShowMessage(true)
-    
-    // Hide message after 2 seconds
-    setTimeout(() => {
-      setShowMessage(false)
-    }, 2000)
-  }
-
   const nextItem = () => {
     if (isTransitioning || displayItems.length <= 1) return
     setIsTransitioning(true)
     setCurrentIndex((prev) => (prev + 1) % displayItems.length)
-    showSwipeMessage('next')
     setTimeout(() => setIsTransitioning(false), 300)
   }
 
@@ -78,7 +39,6 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
     if (isTransitioning || displayItems.length <= 1) return
     setIsTransitioning(true)
     setCurrentIndex((prev) => (prev - 1 + displayItems.length) % displayItems.length)
-    showSwipeMessage('prev')
     setTimeout(() => setIsTransitioning(false), 300)
   }
 
@@ -106,19 +66,6 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
     touchStartX.current = 0
     touchEndX.current = 0
   }
-
-  // Remove auto-advance functionality - commented out
-  // useEffect(() => {
-  //   if (displayItems.length <= 1) return
-  //   
-  //   const interval = setInterval(() => {
-  //     if (!isTransitioning) {
-  //       nextItem()
-  //     }
-  //   }, 10000)
-  //
-  //   return () => clearInterval(interval)
-  // }, [currentIndex, isTransitioning, displayItems.length])
 
   if (displayItems.length === 0) {
     return (
@@ -174,25 +121,23 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
       
       <div className="swipeable-card-content">
         <div 
-          className={`swipeable-item-container ${isTransitioning ? 'transitioning' : ''}`}
-          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+          className="flex h-full transition-transform duration-300 ease-in-out"
+          style={{ 
+            transform: `translateX(-${currentIndex * 100}%)`,
+            width: `${displayItems.length * 100}%`
+          }}
         >
           {displayItems.map((item, index) => (
-            <div key={index} className="swipeable-item">
+            <div 
+              key={index} 
+              className="flex-shrink-0 h-full p-3 overflow-hidden"
+              style={{ width: `${100 / displayItems.length}%` }}
+            >
               {renderItem(item, index)}
             </div>
           ))}
         </div>
       </div>
-
-      {/* Swipe Message Overlay */}
-      {showMessage && (
-        <div className="absolute inset-0 bg-black/70 flex items-center justify-center z-10 transition-opacity duration-300">
-          <div className="bg-slate-800/90 border border-slate-600 rounded-lg px-4 py-3 text-center backdrop-blur-sm">
-            <p className="text-slate-100 text-sm font-medium">{messageText}</p>
-          </div>
-        </div>
-      )}
 
       {/* Swipe indicator dots */}
       <div className="swipeable-card-dots">
@@ -203,7 +148,6 @@ const SwipeableCard: React.FC<SwipeableCardProps> = ({
               if (!isTransitioning) {
                 setIsTransitioning(true)
                 setCurrentIndex(index)
-                showSwipeMessage(index > currentIndex ? 'next' : 'prev')
                 setTimeout(() => setIsTransitioning(false), 300)
               }
             }}

--- a/src/index.css
+++ b/src/index.css
@@ -757,31 +757,41 @@ html, body {
 @media (max-width: 768px) {
   .swipeable-card {
     width: 90vw;
-    height: 45vw;
+    height: auto;
     min-width: 90vw;
-    min-height: 45vw;
+    min-height: 200px;
     max-width: 90vw;
-    max-height: 45vw;
+    max-height: none;
   }
 }
 
 @media (max-width: 480px) {
   .swipeable-card {
     width: 95vw;
-    height: 50vw;
+    height: auto;
     min-width: 95vw;
-    min-height: 50vw;
+    min-height: 180px;
     max-width: 95vw;
-    max-height: 50vw;
+    max-height: none;
   }
 }
 
 .swipeable-card-header {
-  @apply p-3 border-b border-slate-600/30 flex-shrink-0;
+  @apply p-2 sm:p-3 border-b border-slate-600/30 flex-shrink-0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .swipeable-card-content {
   @apply flex-1 overflow-hidden relative;
+  min-height: 120px;
+}
+
+@media (max-width: 768px) {
+  .swipeable-card-content {
+    min-height: 100px;
+  }
 }
 
 /* Removed swipeable-item-container and swipeable-item classes - now handled inline */

--- a/src/index.css
+++ b/src/index.css
@@ -784,19 +784,7 @@ html, body {
   @apply flex-1 overflow-hidden relative;
 }
 
-.swipeable-item-container {
-  @apply flex h-full transition-transform duration-300 ease-in-out;
-  width: calc(100% * var(--item-count, 10));
-}
-
-.swipeable-item-container.transitioning {
-  transition-duration: 300ms;
-}
-
-.swipeable-item {
-  @apply flex-shrink-0 w-full h-full p-3 overflow-hidden;
-  width: calc(100% / var(--item-count, 10));
-}
+/* Removed swipeable-item-container and swipeable-item classes - now handled inline */
 
 .swipeable-card-dots {
   @apply flex justify-center gap-1 p-2 flex-shrink-0;
@@ -873,6 +861,13 @@ html, body {
 .line-clamp-3 {
   display: -webkit-box;
   -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.line-clamp-4 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }


### PR DESCRIPTION
Fix blank card content on mobile and remove unwanted click/swipe messages.

Cards appeared blank on mobile due to incorrect CSS width calculations (using an unset CSS variable) and fixed viewport-based heights that were too small, causing content to be cut off. This PR corrects these styling issues and removes the explicitly requested click/swipe notification messages.

---

[Open in Web](https://www.cursor.com/agents?id=bc-62ada7b2-b452-4b2c-bf7c-1f4800a788f7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-62ada7b2-b452-4b2c-bf7c-1f4800a788f7)