### PR TITLE
Fix double swipe animation on cards

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -889,12 +889,12 @@ html, body {
 }
 
 .book-page-flip-left {
-  transform: rotateY(-180deg);
+  transform: rotateY(180deg);
   backface-visibility: hidden;
 }
 
 .book-page-flip-right {
-  transform: rotateY(180deg);
+  transform: rotateY(-180deg);
   backface-visibility: hidden;
 }
 
@@ -906,7 +906,7 @@ html, body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(to right, 
+  background: linear-gradient(to left, 
     rgba(0, 0, 0, 0.1) 0%, 
     rgba(0, 0, 0, 0.05) 50%, 
     rgba(0, 0, 0, 0) 100%
@@ -924,7 +924,7 @@ html, body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(to left, 
+  background: linear-gradient(to right, 
     rgba(0, 0, 0, 0.1) 0%, 
     rgba(0, 0, 0, 0.05) 50%, 
     rgba(0, 0, 0, 0) 100%


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correct book page flip animation direction and shadows to fix double swipe effect on single cards.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, swiping left would cause the card to animate right then left, and vice-versa for swiping right, due to inverted `rotateY` values and shadow gradients. This PR ensures the animation correctly follows the swipe direction.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d85b7bbb-51ef-4171-b133-198b8be2ec11) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d85b7bbb-51ef-4171-b133-198b8be2ec11)