### PR TITLE
Tablet mode news feed removal and sidebar integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,6 @@ function App() {
                   <Layout>
                     <Routes>
                       <Route path="/" element={<HomePage />} />
-                      <Route path="/classic" element={<HomePage />} />
                       <Route path="/auth" element={<AuthPage />} />
                       <Route path="/community" element={<CommunityPage />} />
                       <Route path="/retro" element={<HomeScreenRetro />} />

--- a/src/components/HomeScreenRetro.tsx
+++ b/src/components/HomeScreenRetro.tsx
@@ -47,7 +47,7 @@ const HomeScreenRetro: React.FC = () => {
             <Target className="w-7 h-7 text-accent-purple mx-auto" />
           </div>
           <div className="simple-tile-label">
-            <div className="typography-small font-medium text-text-primary">{t('nav.quiz')}</div>
+            <div className="font-medium text-text-primary text-sm">{t('nav.quiz')}</div>
             <div className="text-xs text-text-muted">{t('home.quiz.subtitle')}</div>
           </div>
         </Link>

--- a/src/components/HomeScreenRetro.tsx
+++ b/src/components/HomeScreenRetro.tsx
@@ -192,7 +192,7 @@ const HomeScreenRetro: React.FC = () => {
           {t('home.footer.retro')} - {t('home.footer.n64')}
         </p>
         <Link 
-          to="/classic" 
+          to="/" 
           className="inline-block mt-3 px-4 py-2 rounded-lg transition-all duration-200 text-sm font-medium"
           style={{
             backgroundColor: 'rgba(30, 144, 255, 0.2)',
@@ -208,7 +208,7 @@ const HomeScreenRetro: React.FC = () => {
             e.currentTarget.style.color = '#1E90FF'
           }}
         >
-          📰 {t('home.footer.classic')}
+          🏠 Zurück zur Hauptseite
         </Link>
       </div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -67,8 +67,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose }) => {
                   <span className="truncate">{t('nav.home')}</span>
                 </Link>
               </li>
-              <li className={location.pathname === '/classic' ? 'active' : ''}>
-                <Link to="/classic" onClick={handleLinkClick} className="nav-link">
+              <li className={location.pathname === '/retro' ? 'active' : ''}>
+                <Link to="/retro" onClick={handleLinkClick} className="nav-link">
                   <span className="mr-2 sm:mr-3">🎮</span>
                   <span className="truncate">{t('nav.classic')}</span>
                 </Link>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -503,12 +503,6 @@ const HomePage: React.FC = () => {
         <p className="text-responsive-sm text-slate-400 responsive-word-break">
           {t('home.footer.tagline')}
         </p>
-        <Link 
-          to="/retro" 
-          className="inline-block mt-4 px-4 py-2 rounded-lg bg-slate-700/50 hover:bg-slate-600/50 transition-colors text-responsive-sm text-slate-300 w-full sm:w-auto"
-        >
-          🎮 {t('home.footer.classic')}
-        </Link>
       </div>
     </div>
   )


### PR DESCRIPTION
Relocate 'Tablet Mode' access from the homepage footer to the sidebar and fix Quiz tile alignment in the retro view for improved navigation and UI consistency.

---

[Open in Web](https://www.cursor.com/agents?id=bc-004453d1-7879-4923-b5f1-5bcf5c35eaba) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-004453d1-7879-4923-b5f1-5bcf5c35eaba)