### PR TITLE
Localize and clean UI labels

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1363,6 +1363,8 @@ const translations = {
     'minigames.tournamentsDesc': 'Participate in weekly mini-game tournaments!',
     'minigames.currentTournaments': '🎯 Current Tournaments',
     'minigames.multiplayer': 'Multiplayer',
+    'minigames.available': 'Available',
+    'minigames.games': 'Games',
 
     // Collection Manager
     'collection.myCollection': 'My Collection',
@@ -1662,6 +1664,12 @@ const translations = {
     'leaderboard.seasonLeaderboard': 'Season Leaderboard',
     'leaderboard.filterType': 'Type',
     'leaderboard.timeframe': 'Timeframe',
+    'leaderboard.filterGlobal': 'Global',
+    'leaderboard.filterFriends': 'Friends',
+    'leaderboard.filterRegion': 'Local',
+    'leaderboard.timeframeAllTime': 'All Time',
+    'leaderboard.timeframeSeason': 'This Week',
+    'leaderboard.timeframeMonth': 'Today',
 
     // Placeholders and form text
     'placeholder.additionalInfo': 'Additional information...',


### PR DESCRIPTION
Add missing English i18n translations for leaderboard filters and minigames to ensure clean UI labels.

Previously, raw i18n keys were displayed in the UI due to missing English entries, leading to a poor user experience and failing to meet UX requirements for polished labels.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b0e48b9d-a913-4998-b01f-56859c59c1c6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b0e48b9d-a913-4998-b01f-56859c59c1c6)