### PR TITLE
Replace title with mascot on homepage and retro

### DIFF
--- a/src/components/HomeScreenRetro.tsx
+++ b/src/components/HomeScreenRetro.tsx
@@ -23,20 +23,15 @@ const HomeScreenRetro: React.FC = () => {
 
   return (
     <div className="retro-page container mx-auto px-4 py-6">
-      {/* Header with Mascot and Battle64 Branding */}
+      {/* Header with Mascot */}
       <div className="text-center mb-8">
         <div className="battle64-header-container mb-4">
-          {/* Mascot Image - Left side on desktop, below title on mobile */}
+          {/* Mascot Image */}
           <img 
             src="/mascot.png" 
             alt="Battle64 CRT-TV Mascot" 
             className="battle64-mascot h-64 md:h-80 lg:h-96 w-auto object-contain"
           />
-          
-          {/* Battle64 Title - Right side on desktop, above mascot on mobile */}
-          <h1 className="battle64-title text-8xl md:text-9xl lg:text-10xl font-bold">
-            Battle64
-          </h1>
         </div>
         
         {/* Welcome Back Text */}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -385,20 +385,15 @@ const HomePage: React.FC = () => {
 
   return (
     <div className="container-lg py-responsive space-responsive responsive-max-width responsive-overflow-hidden">
-      {/* Welcome Section with Mascot and Battle64 Branding */}
+      {/* Welcome Section with Mascot */}
       <div className="text-center mb-responsive responsive-max-width">
         <div className="battle64-header-container mb-4">
-          {/* Mascot Image - Left side on desktop, below title on mobile */}
+          {/* Mascot Image */}
           <img 
             src="/mascot.png" 
             alt="Battle64 CRT-TV Mascot" 
-            className="battle64-mascot h-48 md:h-64 lg:h-80 w-auto object-contain"
+            className="battle64-mascot h-64 md:h-80 lg:h-96 w-auto object-contain"
           />
-          
-          {/* Battle64 Title - Right side on desktop, above mascot on mobile */}
-          <h1 className="battle64-title text-6xl md:text-8xl lg:text-10xl font-bold responsive-word-break">
-            Battle64
-          </h1>
         </div>
         
         {/* Welcome Back Text */}


### PR DESCRIPTION
Remove "Battle64" titles and standardize mascot size on homepage and retro pages to display only the mascot.

---

[Open in Web](https://www.cursor.com/agents?id=bc-4044d87f-4ad5-41af-bcf1-875e7c0a52d5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4044d87f-4ad5-41af-bcf1-875e7c0a52d5)