### PR TITLE
Maskottchen breiter machen auf homepage und retro

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1813,10 +1813,12 @@ html, body {
   transition: transform 0.3s ease;
   /* Ensure exact height matching with title */
   object-fit: contain;
+  /* Stretch horizontally to make it wider but keep same height */
+  transform: scaleX(1.3);
 }
 
 .battle64-mascot:hover {
-  transform: scale(1.05) rotate(1deg);
+  transform: scaleX(1.37) scaleY(1.05) rotate(1deg);
 }
 
 


### PR DESCRIPTION
Stretch the mascot horizontally on homepage and retro page to make it appear wider.

This change was requested by the user to make the mascot take up more horizontal screen space without increasing its height.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b9ef9376-823c-4308-bdaf-7f8dee782ff1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b9ef9376-823c-4308-bdaf-7f8dee782ff1)