### PR TITLE
Verbessere news karten auf homepage

### DIFF
--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Newspaper, X } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
 
 interface NewsItem {
@@ -19,12 +20,21 @@ interface NewsCardProps {
 
 const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index, onDismiss, isAnimating = false }) => {
   const { t, currentLanguage } = useLanguage()
+  const navigate = useNavigate()
   
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString(getLocaleString(currentLanguage), {
       hour: '2-digit',
       minute: '2-digit'
     })
+  }
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    // Don't navigate if clicking the dismiss button
+    if ((e.target as HTMLElement).closest('button')) {
+      return
+    }
+    navigate('/newsfeed')
   }
 
   const getTypeColor = (type: string) => {
@@ -75,7 +85,10 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index, onDismiss, isAnima
   }
 
   return (
-    <div className={`swipeable-card ${getCardClass(newsItem.type)} relative transition-all duration-300 ${isAnimating ? 'scale-95 opacity-80' : 'scale-100 opacity-100'}`}>
+    <div 
+      className={`swipeable-card ${getCardClass(newsItem.type)} relative transition-all duration-300 ${isAnimating ? 'scale-95 opacity-80' : 'scale-100 opacity-100'}`}
+      onClick={handleCardClick}
+    >
       {/* Event Winner Label */}
       {newsItem.type === 'event_winner' && (
         <div className="news-event-winner-label">
@@ -110,8 +123,8 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index, onDismiss, isAnima
       
       <div className="swipeable-card-header">
         <div className="flex items-center gap-2">
-          <Newspaper className="w-5 h-5 text-accent-blue" />
-          <h3 className="text-responsive-base font-bold text-text-primary">
+          <Newspaper className="w-4 h-4 text-accent-blue" />
+          <h3 className="text-sm font-bold text-text-primary">
             {t('news.title')} #{index + 1}
           </h3>
         </div>
@@ -123,17 +136,17 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index, onDismiss, isAnima
       </div>
       
       <div className="swipeable-card-content">
-        <div className="p-4 h-full flex flex-col">
-          <div className="flex-1">
-            <h4 className="text-base sm:text-lg font-semibold text-text-primary mb-3 leading-tight">
+        <div className="p-4 h-full flex flex-col justify-between">
+          <div className="flex-1 space-y-3">
+            <h4 className="text-base font-semibold text-text-primary leading-tight line-clamp-2">
               {newsItem.title}
             </h4>
-            <p className="text-base text-text-secondary mb-4 leading-relaxed line-clamp-2">
+            <p className="text-sm text-text-secondary leading-relaxed line-clamp-3">
               {newsItem.content}
             </p>
           </div>
-          <div className="border-t border-slate-600/30 pt-3 mt-auto">
-            <div className="flex items-center justify-between text-sm text-text-muted">
+          <div className="border-t border-slate-600/30 pt-3 mt-4 flex-shrink-0">
+            <div className="flex items-center justify-between text-xs text-text-muted">
               <span className="font-medium">{formatTime(newsItem.date)}</span>
               <span className="text-accent-blue font-medium">{t('ui.newsDetails')}</span>
             </div>

--- a/src/components/SingleNewsCard.tsx
+++ b/src/components/SingleNewsCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react'
 import { Newspaper } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import NewsCard from './NewsCard'
 import { useLanguage } from '../contexts/LanguageContext'
 
@@ -18,6 +19,7 @@ interface SingleNewsCardProps {
 
 const SingleNewsCard: React.FC<SingleNewsCardProps> = ({ newsItems, className = '' }) => {
   const { t } = useLanguage()
+  const navigate = useNavigate()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isFlipping, setIsFlipping] = useState(false)
   const [flipDirection, setFlipDirection] = useState<'left' | 'right'>('left')
@@ -185,6 +187,16 @@ const SingleNewsCard: React.FC<SingleNewsCardProps> = ({ newsItems, className = 
         {/* Card counter */}
         <div className="text-center mt-1 text-xs text-slate-400">
           {currentIndex + 1} {t('common.of')} {newsItems.length}
+        </div>
+        
+        {/* View All News Button */}
+        <div className="text-center mt-3">
+          <button
+            onClick={() => navigate('/newsfeed')}
+            className="text-xs text-accent-blue hover:text-blue-300 transition-colors duration-200 font-medium"
+          >
+View All News →
+          </button>
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1745,19 +1745,19 @@ code {
 
 /* Responsive Swipeable Card Styles - N64 Theme */
 .swipeable-card {
-  @apply rounded-lg shadow-lg transition-all duration-300 hover:shadow-xl backdrop-blur-sm;
+  @apply rounded-lg shadow-lg transition-all duration-300 hover:shadow-xl backdrop-blur-sm cursor-pointer;
   background: rgba(24, 26, 44, 0.8);
   border: 1px solid rgba(44, 47, 74, 0.8);
   width: 100%;
   max-width: min(400px, 90vw);
   height: auto;
-  min-height: clamp(200px, 25vh, 300px);
+  min-height: clamp(280px, 35vh, 380px);
   position: relative;
   overflow: hidden;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  aspect-ratio: 16/10;
+  aspect-ratio: 16/11;
 }
 
 /* Responsive card container */
@@ -1839,21 +1839,35 @@ input[type="submit"] {
 }
 
 .swipeable-card-header {
-  @apply p-2 sm:p-3 flex-shrink-0;
+  @apply p-3 flex-shrink-0;
   border-bottom: 1px solid rgba(44, 47, 74, 0.5);
   display: flex;
   justify-content: space-between;
   align-items: center;
+  min-height: 50px;
 }
 
 .swipeable-card-content {
-  @apply flex-1 overflow-hidden relative;
-  min-height: 120px;
+  @apply flex-1 relative;
+  min-height: 160px;
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 768px) {
   .swipeable-card-content {
-    min-height: 100px;
+    min-height: 140px;
+  }
+  
+  .swipeable-card {
+    min-height: clamp(260px, 32vh, 340px);
+    aspect-ratio: 16/10.5;
+  }
+  
+  .swipeable-card-header {
+    padding: 0.75rem;
+    min-height: 45px;
   }
 }
 
@@ -1898,6 +1912,30 @@ input[type="submit"] {
   max-width: 100%;
   overflow-x: auto;
   padding: 0 1rem;
+}
+
+/* Improved text clamping for consistent card heights */
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Enhanced hover effect for news cards */
+.swipeable-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
+  border-color: rgba(59, 130, 246, 0.5);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Improve news cards on the homepage by fixing text overflow, standardizing font sizes, and adding click navigation to the full news feed.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a03fc02-db1d-4764-8c65-2a0370878fb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a03fc02-db1d-4764-8c65-2a0370878fb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>