### PR TITLE
Update homepage cards with post previews and links

### DIFF
--- a/src/components/SingleFanArtCard.tsx
+++ b/src/components/SingleFanArtCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { Palette, Heart, Eye } from 'lucide-react'
 import { useLanguage } from '../contexts/LanguageContext'
+import { useNavigate } from 'react-router-dom'
 
 interface FanArtItem {
   id: string
@@ -10,6 +11,7 @@ interface FanArtItem {
   likes: number
   views: number
   game: string
+  createdAt?: Date
 }
 
 interface SingleFanArtCardProps {
@@ -19,6 +21,7 @@ interface SingleFanArtCardProps {
 
 const SingleFanArtCard: React.FC<SingleFanArtCardProps> = ({ fanArtItems, className = '' }) => {
   const { t } = useLanguage()
+  const navigate = useNavigate()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isFlipping, setIsFlipping] = useState(false)
   const [flipDirection, setFlipDirection] = useState<'left' | 'right'>('left')
@@ -74,6 +77,11 @@ const SingleFanArtCard: React.FC<SingleFanArtCardProps> = ({ fanArtItems, classN
     touchEndX.current = 0
   }
 
+  const handleCardClick = (item: FanArtItem) => {
+    // Navigate to FanArt page and scroll to the specific post
+    navigate('/fanart', { state: { highlightPostId: item.id } })
+  }
+
   if (fanArtItems.length === 0) {
     return (
       <div className={`${className} flex justify-center`}>
@@ -95,7 +103,10 @@ const SingleFanArtCard: React.FC<SingleFanArtCardProps> = ({ fanArtItems, classN
   }
 
   const renderFanArtCard = (item: FanArtItem, index: number, isAnimating: boolean = false) => (
-    <div className={`swipeable-card bg-gradient-to-br from-rose-600/10 to-pink-600/10 border-l-4 border-rose-400 relative transition-all duration-300 ${isAnimating ? 'scale-95 opacity-80' : 'scale-100 opacity-100'}`}>
+    <div 
+      className={`swipeable-card bg-gradient-to-br from-rose-600/10 to-pink-600/10 border-l-4 border-rose-400 relative transition-all duration-300 cursor-pointer hover:scale-105 ${isAnimating ? 'scale-95 opacity-80' : 'scale-100 opacity-100'}`}
+      onClick={() => handleCardClick(item)}
+    >
       <div className="swipeable-card-header">
         <div className="flex items-center gap-2">
           <Palette className="w-5 h-5 text-rose-400" />
@@ -109,8 +120,24 @@ const SingleFanArtCard: React.FC<SingleFanArtCardProps> = ({ fanArtItems, classN
       <div className="swipeable-card-content">
         <div className="p-3 h-full flex flex-col">
           <div className="flex-1 mb-2">
-            <div className="w-full h-16 bg-slate-700 rounded mb-2 flex items-center justify-center">
-              <Palette className="w-6 h-6 text-slate-400" />
+            {/* Display actual image */}
+            <div className="w-full h-16 bg-slate-700 rounded mb-2 overflow-hidden">
+              {item.imageUrl ? (
+                <img 
+                  src={item.imageUrl} 
+                  alt={item.title}
+                  className="w-full h-full object-cover"
+                  onError={(e) => {
+                    // Fallback to placeholder if image fails to load
+                    const target = e.target as HTMLImageElement
+                    target.style.display = 'none'
+                    target.nextElementSibling?.classList.remove('hidden')
+                  }}
+                />
+              ) : null}
+              <div className={`w-full h-full flex items-center justify-center ${item.imageUrl ? 'hidden' : ''}`}>
+                <Palette className="w-6 h-6 text-slate-400" />
+              </div>
             </div>
             <h4 className="text-sm sm:text-base font-semibold text-slate-100 mb-1 leading-tight">
               {item.title}
@@ -127,6 +154,11 @@ const SingleFanArtCard: React.FC<SingleFanArtCardProps> = ({ fanArtItems, classN
                 <Eye className="w-3 h-3" /> {item.views}
               </span>
             </div>
+            {item.createdAt && (
+              <span className="text-xs">
+                {item.createdAt.toLocaleDateString()}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/SingleForumCard.tsx
+++ b/src/components/SingleForumCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { MessageCircle } from 'lucide-react'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
+import { useNavigate } from 'react-router-dom'
 
 interface ForumThread {
   id: string
@@ -9,6 +10,8 @@ interface ForumThread {
   replies: number
   lastActivity: Date
   category: string
+  lastPostContent?: string
+  lastPostAuthor?: string
 }
 
 interface SingleForumCardProps {
@@ -18,6 +21,7 @@ interface SingleForumCardProps {
 
 const SingleForumCard: React.FC<SingleForumCardProps> = ({ forumThreads, className = '' }) => {
   const { t, currentLanguage } = useLanguage()
+  const navigate = useNavigate()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isFlipping, setIsFlipping] = useState(false)
   const [flipDirection, setFlipDirection] = useState<'left' | 'right'>('left')
@@ -80,8 +84,16 @@ const SingleForumCard: React.FC<SingleForumCardProps> = ({ forumThreads, classNa
     touchEndX.current = 0
   }
 
+  const handleCardClick = (thread: ForumThread) => {
+    // Navigate to the specific forum thread
+    navigate(`/forum/thread/${thread.id}`)
+  }
+
   const renderForumCard = (thread: ForumThread, index: number, isAnimating: boolean = false) => (
-    <div className={`swipeable-card bg-gradient-to-br from-cyan-600/10 to-blue-600/10 border-l-4 border-cyan-400 relative transition-all duration-300 ${isAnimating ? 'scale-95 opacity-80' : 'scale-100 opacity-100'}`}>
+    <div 
+      className={`swipeable-card bg-gradient-to-br from-cyan-600/10 to-blue-600/10 border-l-4 border-cyan-400 relative transition-all duration-300 cursor-pointer hover:scale-105 ${isAnimating ? 'scale-95 opacity-80' : 'scale-100 opacity-100'}`}
+      onClick={() => handleCardClick(thread)}
+    >
       <div className="swipeable-card-header">
         <div className="flex items-center gap-2">
           <MessageCircle className="w-5 h-5 text-cyan-400" />
@@ -101,6 +113,17 @@ const SingleForumCard: React.FC<SingleForumCardProps> = ({ forumThreads, classNa
             <div className="text-xs text-slate-300 mb-2">
               <span className="text-blue-400">{thread.author}</span> • {thread.category}
             </div>
+            {/* Show last post content if available */}
+            {thread.lastPostContent && (
+              <div className="text-xs text-slate-400 mb-2 line-clamp-2">
+                <span className="text-cyan-400">Letzte Antwort von {thread.lastPostAuthor || 'Unbekannt'}:</span>
+                <br />
+                {thread.lastPostContent.length > 80 
+                  ? `${thread.lastPostContent.substring(0, 80)}...` 
+                  : thread.lastPostContent
+                }
+              </div>
+            )}
           </div>
           <div className="flex items-center justify-between text-xs text-slate-400 mt-auto">
             <span>{thread.replies} Antworten</span>

--- a/src/components/SingleMarketplaceCard.tsx
+++ b/src/components/SingleMarketplaceCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { ShoppingBag } from 'lucide-react'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
+import { useNavigate } from 'react-router-dom'
 
 interface MarketplaceItem {
   id: string
@@ -11,6 +12,7 @@ interface MarketplaceItem {
   seller: string
   date: Date
   image?: string
+  images?: string[]
   category: string
 }
 
@@ -21,6 +23,7 @@ interface SingleMarketplaceCardProps {
 
 const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketplaceItems, className = '' }) => {
   const { t, currentLanguage } = useLanguage()
+  const navigate = useNavigate()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isFlipping, setIsFlipping] = useState(false)
   const [flipDirection, setFlipDirection] = useState<'left' | 'right'>('left')
@@ -83,6 +86,11 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
     touchEndX.current = 0
   }
 
+  const handleCardClick = (item: MarketplaceItem) => {
+    // Navigate to marketplace page and highlight the specific item
+    navigate('/marktplatz', { state: { highlightItemId: item.id } })
+  }
+
   if (marketplaceItems.length === 0) {
     return (
       <div className={`${className} flex justify-center`}>
@@ -104,6 +112,7 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
   }
 
   const currentItem = marketplaceItems[currentIndex]
+  const itemImage = currentItem.images?.[0] || currentItem.image
 
   return (
     <div className={`${className} flex justify-center`}>
@@ -130,6 +139,16 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
                   <div className="swipeable-card-content">
                     <div className="p-4 h-full flex flex-col">
                       <div className="flex-1">
+                        {/* Image for next item */}
+                        {(marketplaceItems[currentIndex + 1].images?.[0] || marketplaceItems[currentIndex + 1].image) && (
+                          <div className="w-full h-12 bg-slate-700 rounded mb-2 overflow-hidden">
+                            <img 
+                              src={marketplaceItems[currentIndex + 1].images?.[0] || marketplaceItems[currentIndex + 1].image} 
+                              alt={marketplaceItems[currentIndex + 1].title}
+                              className="w-full h-full object-cover"
+                            />
+                          </div>
+                        )}
                         <h4 className="text-base sm:text-lg font-semibold text-text-primary mb-2 leading-tight">
                           {marketplaceItems[currentIndex + 1].title}
                         </h4>
@@ -167,6 +186,16 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
                   <div className="swipeable-card-content">
                     <div className="p-4 h-full flex flex-col">
                       <div className="flex-1">
+                        {/* Image for previous item */}
+                        {(marketplaceItems[currentIndex - 1].images?.[0] || marketplaceItems[currentIndex - 1].image) && (
+                          <div className="w-full h-12 bg-slate-700 rounded mb-2 overflow-hidden">
+                            <img 
+                              src={marketplaceItems[currentIndex - 1].images?.[0] || marketplaceItems[currentIndex - 1].image} 
+                              alt={marketplaceItems[currentIndex - 1].title}
+                              className="w-full h-full object-cover"
+                            />
+                          </div>
+                        )}
                         <h4 className="text-base sm:text-lg font-semibold text-text-primary mb-2 leading-tight">
                           {marketplaceItems[currentIndex - 1].title}
                         </h4>
@@ -194,13 +223,14 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
           )}
           
           <div 
-            className={`relative z-20 transition-transform duration-200 ease-out ${
+            className={`relative z-20 transition-transform duration-200 ease-out cursor-pointer hover:scale-105 ${
               isFlipping 
                 ? flipDirection === 'left' 
                   ? 'transform -translate-x-full opacity-0' 
                   : 'transform translate-x-full opacity-0'
                 : 'transform translate-x-0 opacity-100'
             }`}
+            onClick={() => handleCardClick(currentItem)}
           >
             <div className="swipeable-card bg-gradient-to-br from-purple-600/20 to-purple-800/20 border-l-4 border-accent-purple">
               <div className="swipeable-card-header">
@@ -215,6 +245,21 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
               <div className="swipeable-card-content">
                 <div className="p-4 h-full flex flex-col">
                   <div className="flex-1">
+                    {/* Display actual image */}
+                    {itemImage && (
+                      <div className="w-full h-12 bg-slate-700 rounded mb-2 overflow-hidden">
+                        <img 
+                          src={itemImage} 
+                          alt={currentItem.title}
+                          className="w-full h-full object-cover"
+                          onError={(e) => {
+                            // Hide image if it fails to load
+                            const target = e.target as HTMLImageElement
+                            target.parentElement!.style.display = 'none'
+                          }}
+                        />
+                      </div>
+                    )}
                     <h4 className="text-base sm:text-lg font-semibold text-text-primary mb-2 leading-tight">
                       {currentItem.title}
                     </h4>

--- a/src/pages/FanArtPage.tsx
+++ b/src/pages/FanArtPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useLanguage } from '../contexts/LanguageContext'
 import { useUser } from '../contexts/UserContext'
 import { usePoints } from '../contexts/PointsContext'
+import { useLocation } from 'react-router-dom'
 import { Palette, Heart, Eye, MessageSquare, Upload, Filter, Grid, List, Zap, X, Image as ImageIcon } from 'lucide-react'
 
 interface FanArtItem {
@@ -310,10 +311,12 @@ const FanArtPage: React.FC = () => {
   const { t } = useLanguage()
   const { user, isAuthenticated } = useUser()
   const { awardPoints } = usePoints()
+  const location = useLocation()
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [showUploadModal, setShowUploadModal] = useState(false)
   const [fanArtItems, setFanArtItems] = useState<FanArtItem[]>([])
+  const [highlightedPostId, setHighlightedPostId] = useState<string | null>(null)
 
   // Load FanArt data from localStorage on component mount
   useEffect(() => {
@@ -391,7 +394,24 @@ const FanArtPage: React.FC = () => {
     }
 
     loadFanArtData()
-  }, [])
+
+    // Check if we need to highlight a specific post
+    if (location.state?.highlightPostId) {
+      setHighlightedPostId(location.state.highlightPostId)
+      // Auto-scroll to the highlighted post after a short delay
+      setTimeout(() => {
+        const element = document.getElementById(`fanart-${location.state.highlightPostId}`)
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
+      }, 500)
+      
+      // Clear the highlight after a few seconds
+      setTimeout(() => {
+        setHighlightedPostId(null)
+      }, 3000)
+    }
+  }, [location.state])
 
   const categories = [
     { id: 'all', name: t('fanart.allCategories') },
@@ -580,7 +600,13 @@ const FanArtPage: React.FC = () => {
       {viewMode === 'grid' ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredItems.map(item => (
-            <div key={item.id} className="n64-tile bg-slate-800/50 hover:bg-slate-800/70 transition-colors">
+            <div 
+              key={item.id} 
+              id={`fanart-${item.id}`}
+              className={`n64-tile bg-slate-800/50 hover:bg-slate-800/70 transition-colors ${
+                highlightedPostId === item.id ? 'ring-2 ring-rose-500' : ''
+              }`}
+            >
               <div className="aspect-video bg-slate-700 rounded-lg mb-4 overflow-hidden">
                 <img 
                   src={item.imageUrl} 
@@ -654,7 +680,13 @@ const FanArtPage: React.FC = () => {
       ) : (
         <div className="space-y-4">
           {filteredItems.map(item => (
-            <div key={item.id} className="n64-tile bg-slate-800/50 hover:bg-slate-800/70 transition-colors">
+            <div 
+              key={item.id} 
+              id={`fanart-${item.id}`}
+              className={`n64-tile bg-slate-800/50 hover:bg-slate-800/70 transition-colors ${
+                highlightedPostId === item.id ? 'ring-2 ring-rose-500' : ''
+              }`}
+            >
               <div className="flex gap-4">
                 <div className="w-32 h-20 bg-slate-700 rounded-lg overflow-hidden flex-shrink-0">
                   <img 

--- a/src/pages/FanArtPage.tsx
+++ b/src/pages/FanArtPage.tsx
@@ -324,14 +324,14 @@ const FanArtPage: React.FC = () => {
       try {
         const savedFanArt = localStorage.getItem('fanart_items')
         if (savedFanArt) {
-          const parsedFanArt = JSON.parse(savedFanArt)
+          const parsedFanArt = JSON.parse(savedFanArt) as FanArtItem[]
           // Convert date strings back to Date objects and sort by newest first
           const sortedFanArt = parsedFanArt
-            .map((item: any) => ({
+            .map((item: FanArtItem) => ({
               ...item,
               createdAt: item.createdAt ? new Date(item.createdAt) : new Date()
             }))
-            .sort((a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            .sort((a: FanArtItem, b: FanArtItem) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
           setFanArtItems(sortedFanArt)
         } else {
           // Use default mock data if no saved data exists

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,14 +12,6 @@ import SingleMediaCard from '../components/SingleMediaCard'
 import SingleRecordCard from '../components/SingleRecordCard'
 import SingleMarketplaceCard from '../components/SingleMarketplaceCard'
 
-interface NewsItem {
-  id: string
-  title: string
-  content: string
-  date: Date
-  type: 'event_winner' | 'n64_history' | 'community_news' | 'event_announcement'
-}
-
 interface ForumThread {
   id: string
   title: string
@@ -40,6 +32,7 @@ interface FanArtItem {
   views: number
   game: string
   createdAt?: Date
+  date?: Date // Add date property for backward compatibility
 }
 
 interface MediaItem {
@@ -77,6 +70,7 @@ interface MarketplaceItem {
   category: string
   images?: string[]
   image?: string
+  createdAt?: string // Add createdAt property for backward compatibility
 }
 
 const HomePage: React.FC = () => {
@@ -113,15 +107,15 @@ const HomePage: React.FC = () => {
       try {
         const savedFanArt = localStorage.getItem('fanart_items')
         if (savedFanArt) {
-          const parsedFanArt = JSON.parse(savedFanArt)
+          const parsedFanArt = JSON.parse(savedFanArt) as FanArtItem[]
           // Sort by date (newest first) and convert date strings back to Date objects
           const sortedFanArt = parsedFanArt
-            .map((item: any) => ({
+            .map((item: FanArtItem) => ({
               ...item,
               createdAt: item.createdAt ? new Date(item.createdAt) : new Date(),
               date: item.date ? new Date(item.date) : new Date()
             }))
-            .sort((a: any, b: any) => {
+            .sort((a: FanArtItem, b: FanArtItem) => {
               const dateA = a.createdAt || a.date || new Date(0)
               const dateB = b.createdAt || b.date || new Date(0)
               return dateB.getTime() - dateA.getTime()
@@ -148,14 +142,14 @@ const HomePage: React.FC = () => {
       try {
         const savedMarketplace = localStorage.getItem('marketplace_items')
         if (savedMarketplace) {
-          const parsedMarketplace = JSON.parse(savedMarketplace)
+          const parsedMarketplace = JSON.parse(savedMarketplace) as MarketplaceItem[]
           // Sort by date (newest first) and convert date strings back to Date objects
           const sortedMarketplace = parsedMarketplace
-            .map((item: any) => ({
+            .map((item: MarketplaceItem) => ({
               ...item,
               date: item.date ? new Date(item.date) : (item.createdAt ? new Date(item.createdAt) : new Date())
             }))
-            .sort((a: any, b: any) => b.date.getTime() - a.date.getTime())
+            .sort((a: MarketplaceItem, b: MarketplaceItem) => b.date.getTime() - a.date.getTime())
           setMarketplaceItems(sortedMarketplace)
         } else {
           // Use fallback mock data if no saved data exists

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -27,6 +27,8 @@ interface ForumThread {
   replies: number
   lastActivity: Date
   category: string
+  lastPostContent?: string
+  lastPostAuthor?: string
 }
 
 interface FanArtItem {
@@ -37,6 +39,7 @@ interface FanArtItem {
   likes: number
   views: number
   game: string
+  createdAt?: Date
 }
 
 interface MediaItem {
@@ -72,6 +75,8 @@ interface MarketplaceItem {
   seller: string
   date: Date
   category: string
+  images?: string[]
+  image?: string
 }
 
 const HomePage: React.FC = () => {
@@ -81,6 +86,9 @@ const HomePage: React.FC = () => {
 
   // Load FanArt data from localStorage or use mock data
   const [fanArtItems, setFanArtItems] = useState<FanArtItem[]>([])
+  
+  // Load Marketplace data from localStorage
+  const [marketplaceItems, setMarketplaceItems] = useState<MarketplaceItem[]>([])
   
   // Load other data from localStorage or use mock data
   const [mediaItems] = useState<MediaItem[]>([
@@ -99,14 +107,6 @@ const HomePage: React.FC = () => {
     { id: '5', game: 'Perfect Dark', category: 'DataDyne Central', time: '1:23.45', date: new Date(Date.now() - 18000000), verified: true, platform: 'N64' }
   ])
 
-  const [marketplaceItems] = useState<MarketplaceItem[]>([
-    { id: '1', title: 'Super Mario 64 - Mint Condition', description: 'Original cartridge in mint condition with manual', price: 89.99, condition: 'Mint', seller: 'RetroCollector', date: new Date(Date.now() - 3600000), category: 'Games' },
-    { id: '2', title: 'N64 Controller - Original Nintendo', description: 'Official Nintendo controller in very good condition', price: 34.50, condition: 'Very Good', seller: 'ControllerKing', date: new Date(Date.now() - 7200000), category: 'Accessories' },
-    { id: '3', title: 'GoldenEye 007 - Complete in Box', description: 'Complete game with box, manual, and cartridge', price: 125.00, condition: 'Good', seller: 'GameVault', date: new Date(Date.now() - 10800000), category: 'Games' },
-    { id: '4', title: 'Ocarina of Time - Gold Cartridge', description: 'Rare gold cartridge edition in mint condition', price: 199.99, condition: 'Mint', seller: 'ZeldaFanatic', date: new Date(Date.now() - 14400000), category: 'Collectibles' },
-    { id: '5', title: 'N64 Console - Jungle Green', description: 'Special edition jungle green N64 console', price: 149.99, condition: 'Very Good', seller: 'ConsoleDealer', date: new Date(Date.now() - 18000000), category: 'Consoles' }
-  ])
-
   // Load FanArt data from localStorage on component mount
   useEffect(() => {
     const loadFanArtData = () => {
@@ -118,33 +118,71 @@ const HomePage: React.FC = () => {
           const sortedFanArt = parsedFanArt
             .map((item: any) => ({
               ...item,
+              createdAt: item.createdAt ? new Date(item.createdAt) : new Date(),
               date: item.date ? new Date(item.date) : new Date()
             }))
-            .sort((a: any, b: any) => b.date.getTime() - a.date.getTime())
+            .sort((a: any, b: any) => {
+              const dateA = a.createdAt || a.date || new Date(0)
+              const dateB = b.createdAt || b.date || new Date(0)
+              return dateB.getTime() - dateA.getTime()
+            })
           setFanArtItems(sortedFanArt)
         } else {
           // Use fallback mock data if no saved data exists
           setFanArtItems([
-            { id: '1', title: 'Mario in Peach\'s Castle', artist: 'PixelArtist64', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRkY2QjZCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPk1hcmlvIEFydDwvdGV4dD48L3N2Zz4=', likes: 234, views: 1250, game: 'Super Mario 64' },
-            { id: '2', title: 'Link vs Ganondorf Epic Battle', artist: 'ZeldaDrawer', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjNEVDREMxIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPlplbGRhIEFydDwvdGV4dD48L3N2Zz4=', likes: 189, views: 980, game: 'Ocarina of Time' },
-            { id: '3', title: 'Banjo & Kazooie Adventure', artist: 'RetroSketch', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjNDVCN0QxIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPkJhbmpvIEFydDwvdGV4dD48L3N2Zz4=', likes: 156, views: 750, game: 'Banjo-Kazooie' }
+            { id: '1', title: 'Mario in Peach\'s Castle', artist: 'PixelArtist64', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRkY2QjZCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPk1hcmlvIEFydDwvdGV4dD48L3N2Zz4=', likes: 234, views: 1250, game: 'Super Mario 64', createdAt: new Date() },
+            { id: '2', title: 'Link vs Ganondorf Epic Battle', artist: 'ZeldaDrawer', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjNEVDREMxIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPlplbGRhIEFydDwvdGV4dD48L3N2Zz4=', likes: 189, views: 980, game: 'Ocarina of Time', createdAt: new Date(Date.now() - 86400000) },
+            { id: '3', title: 'Banjo & Kazooie Adventure', artist: 'RetroSketch', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjNDVCN0QxIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPkJhbmpvIEFydDwvdGV4dD48L3N2Zz4=', likes: 156, views: 750, game: 'Banjo-Kazooie', createdAt: new Date(Date.now() - 172800000) }
           ])
         }
       } catch (error) {
         console.error('Error loading fanart data:', error)
         // Use fallback data on error
         setFanArtItems([
-          { id: '1', title: 'Mario in Peach\'s Castle', artist: 'PixelArtist64', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRkY2QjZCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPk1hcmlvIEFydDwvdGV4dD48L3N2Zz4=', likes: 234, views: 1250, game: 'Super Mario 64' }
+          { id: '1', title: 'Mario in Peach\'s Castle', artist: 'PixelArtist64', imageUrl: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRkY2QjZCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjRkZGRkZGIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPk1hcmlvIEFydDwvdGV4dD48L3N2Zz4=', likes: 234, views: 1250, game: 'Super Mario 64', createdAt: new Date() }
+        ])
+      }
+    }
+
+    const loadMarketplaceData = () => {
+      try {
+        const savedMarketplace = localStorage.getItem('marketplace_items')
+        if (savedMarketplace) {
+          const parsedMarketplace = JSON.parse(savedMarketplace)
+          // Sort by date (newest first) and convert date strings back to Date objects
+          const sortedMarketplace = parsedMarketplace
+            .map((item: any) => ({
+              ...item,
+              date: item.date ? new Date(item.date) : (item.createdAt ? new Date(item.createdAt) : new Date())
+            }))
+            .sort((a: any, b: any) => b.date.getTime() - a.date.getTime())
+          setMarketplaceItems(sortedMarketplace)
+        } else {
+          // Use fallback mock data if no saved data exists
+          setMarketplaceItems([
+            { id: '1', title: 'Super Mario 64 - Mint Condition', description: 'Original cartridge in mint condition with manual', price: 89.99, condition: 'Mint', seller: 'RetroCollector', date: new Date(Date.now() - 3600000), category: 'Games', images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPk1hcmlvIDY0PC90ZXh0Pjwvc3ZnPg=='] },
+            { id: '2', title: 'N64 Controller - Original Nintendo', description: 'Official Nintendo controller in very good condition', price: 34.50, condition: 'Very Good', seller: 'ControllerKing', date: new Date(Date.now() - 7200000), category: 'Accessories', images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPkNvbnRyb2xsZXI8L3RleHQ+PC9zdmc+'] },
+            { id: '3', title: 'GoldenEye 007 - Complete in Box', description: 'Complete game with box, manual, and cartridge', price: 125.00, condition: 'Good', seller: 'GameVault', date: new Date(Date.now() - 10800000), category: 'Games', images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPkdvbGRlbkV5ZTwvdGV4dD48L3N2Zz4='] }
+          ])
+        }
+      } catch (error) {
+        console.error('Error loading marketplace data:', error)
+        // Use fallback data on error
+        setMarketplaceItems([
+          { id: '1', title: 'Super Mario 64 - Mint Condition', description: 'Original cartridge in mint condition with manual', price: 89.99, condition: 'Mint', seller: 'RetroCollector', date: new Date(Date.now() - 3600000), category: 'Games' }
         ])
       }
     }
 
     loadFanArtData()
+    loadMarketplaceData()
 
-    // Listen for fanart updates
+    // Listen for data updates
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === 'fanart_items') {
         loadFanArtData()
+      } else if (e.key === 'marketplace_items') {
+        loadMarketplaceData()
       }
     }
 
@@ -152,18 +190,26 @@ const HomePage: React.FC = () => {
     return () => window.removeEventListener('storage', handleStorageChange)
   }, [])
 
-  // Convert forum threads to the format expected by SingleForumCard
+  // Convert forum threads to the format expected by SingleForumCard with enhanced data
   const forumThreads: ForumThread[] = threads
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime())
     .slice(0, 10) // Take top 10 most recent
-    .map(thread => ({
-      id: thread.id,
-      title: thread.title,
-      author: thread.authorName, // Use authorName instead of authorId
-      replies: thread.postCount, // Use postCount for replies
-      lastActivity: new Date(thread.lastUpdated), // Use lastUpdated
-      category: thread.categoryId // Use categoryId instead of category
-    }))
+    .map(thread => {
+      // Find the latest post for this thread
+      const threadPosts = posts.filter(post => post.threadId === thread.id)
+      const latestPost = threadPosts.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]
+      
+      return {
+        id: thread.id,
+        title: thread.title,
+        author: thread.authorName, // Use authorName instead of authorId
+        replies: thread.postCount, // Use postCount for replies
+        lastActivity: new Date(thread.lastUpdated), // Use lastUpdated
+        category: thread.categoryId, // Use categoryId instead of category
+        lastPostContent: latestPost?.content,
+        lastPostAuthor: latestPost?.authorName
+      }
+    })
 
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString(currentLanguage === 'de' ? 'de-DE' : 'en-US', {

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -196,7 +196,6 @@ const MarketplacePage: React.FC = () => {
   const { t } = useLanguage();
   const location = useLocation();
   const [offers, setOffers] = useState<MarketplaceOffer[]>([]);
-  const [filteredOffers, setFilteredOffers] = useState<MarketplaceOffer[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [priceRange] = useState({ min: '', max: '' });

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useLocation } from 'react-router-dom';
 import { Search, Plus, Package, Clock, Star, Grid, List, Eye, MessageCircle, Heart, ShoppingCart } from 'lucide-react';
 
 interface MarketplaceOffer {
@@ -193,83 +194,127 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = ({ isOpen, onClose, on
 
 const MarketplacePage: React.FC = () => {
   const { t } = useLanguage();
+  const location = useLocation();
   const [offers, setOffers] = useState<MarketplaceOffer[]>([]);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [filteredOffers, setFilteredOffers] = useState<MarketplaceOffer[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [priceRange] = useState({ min: '', max: '' });
   const [sortBy, setSortBy] = useState('newest');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [highlightedItemId, setHighlightedItemId] = useState<string | null>(null);
 
-  // Mock data - in a real app, this would come from an API
+  // Load marketplace data from localStorage and handle highlighting
   useEffect(() => {
-    const mockOffers: MarketplaceOffer[] = [
-      {
-        id: '1',
-        title: 'Super Mario 64 - Mint Condition',
-        description: 'Original N64 Spiel in perfektem Zustand mit Originalverpackung und Anleitung.',
-        price: 45.99,
-        currency: 'EUR',
-        condition: 'mint',
-        images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPjMwMHgyMDA8L3RleHQ+PC9zdmc+'],
-        seller: {
-          id: 'user1',
-          name: 'RetroGamer92',
-          rating: 4.8,
-          verified: true
-        },
-        category: 'games',
-        createdAt: '2024-01-15T10:30:00Z',
-        views: 127,
-        likes: 23,
-        comments: 5,
-        isActive: true
-      },
-      {
-        id: '2',
-        title: 'N64 Controller - Original Nintendo',
-        description: 'Originaler N64 Controller in gutem Zustand. Alle Knöpfe funktionieren einwandfrei.',
-        price: 25.00,
-        currency: 'EUR',
-        condition: 'good',
-        images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPjMwMHgyMDA8L3RleHQ+PC9zdmc+'],
-        seller: {
-          id: 'user2',
-          name: 'N64Collector',
-          rating: 4.9,
-          verified: true
-        },
-        category: 'accessories',
-        createdAt: '2024-01-14T15:45:00Z',
-        views: 89,
-        likes: 12,
-        comments: 3,
-        isActive: true
-      },
-      {
-        id: '3',
-        title: 'The Legend of Zelda: Ocarina of Time',
-        description: 'Kultspiel für N64. Modul in sehr gutem Zustand, funktioniert perfekt.',
-        price: 35.50,
-        currency: 'EUR',
-        condition: 'very-good',
-        images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPjMwMHgyMDA8L3RleHQ+PC9zdmc+'],
-        seller: {
-          id: 'user3',
-          name: 'ZeldaFan2000',
-          rating: 4.7,
-          verified: false
-        },
-        category: 'games',
-        createdAt: '2024-01-13T09:20:00Z',
-        views: 156,
-        likes: 31,
-        comments: 8,
-        isActive: true
+    const loadMarketplaceData = () => {
+      try {
+        const savedMarketplace = localStorage.getItem('marketplace_items');
+        if (savedMarketplace) {
+          const parsedMarketplace = JSON.parse(savedMarketplace);
+          const sortedMarketplace = parsedMarketplace
+            .map((item: any) => ({
+              ...item,
+              createdAt: item.createdAt || new Date().toISOString()
+            }))
+            .sort((a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+          setOffers(sortedMarketplace);
+        } else {
+          // Use mock data and save to localStorage
+          const mockOffers: MarketplaceOffer[] = [
+            {
+              id: '1',
+              title: 'Super Mario 64 - Mint Condition',
+              description: 'Original N64 Spiel in perfektem Zustand mit Originalverpackung und Anleitung.',
+              price: 45.99,
+              currency: 'EUR',
+              condition: 'mint',
+              images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPjMwMHgyMDA8L3RleHQ+PC9zdmc+'],
+              seller: {
+                id: 'user1',
+                name: 'RetroGamer92',
+                rating: 4.8,
+                verified: true
+              },
+              category: 'games',
+              createdAt: '2024-01-15T10:30:00Z',
+              views: 127,
+              likes: 23,
+              comments: 5,
+              isActive: true
+            },
+            {
+              id: '2',
+              title: 'N64 Controller - Original Nintendo',
+              description: 'Originaler N64 Controller in gutem Zustand. Alle Knöpfe funktionieren einwandfrei.',
+              price: 25.00,
+              currency: 'EUR',
+              condition: 'good',
+              images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPjMwMHgyMDA8L3RleHQ+PC9zdmc+'],
+              seller: {
+                id: 'user2',
+                name: 'N64Collector',
+                rating: 4.9,
+                verified: true
+              },
+              category: 'accessories',
+              createdAt: '2024-01-14T15:45:00Z',
+              views: 89,
+              likes: 12,
+              comments: 3,
+              isActive: true
+            },
+            {
+              id: '3',
+              title: 'The Legend of Zelda: Ocarina of Time',
+              description: 'Kultspiel für N64. Modul in sehr gutem Zustand, funktioniert perfekt.',
+              price: 35.50,
+              currency: 'EUR',
+              condition: 'very-good',
+              images: ['data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjRTVFN0VCIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjNkI3MjgwIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiPjMwMHgyMDA8L3RleHQ+PC9zdmc+'],
+              seller: {
+                id: 'user3',
+                name: 'ZeldaFan2000',
+                rating: 4.7,
+                verified: false
+              },
+              category: 'games',
+              createdAt: '2024-01-13T09:20:00Z',
+              views: 156,
+              likes: 31,
+              comments: 8,
+              isActive: true
+            }
+          ];
+          setOffers(mockOffers);
+          // Save to localStorage for homepage
+          localStorage.setItem('marketplace_items', JSON.stringify(mockOffers));
+        }
+      } catch (error) {
+        console.error('Error loading marketplace data:', error);
+        setOffers([]);
       }
-    ];
-    setOffers(mockOffers);
-  }, []);
+    };
+
+    loadMarketplaceData();
+
+    // Check if we need to highlight a specific item
+    if (location.state?.highlightItemId) {
+      setHighlightedItemId(location.state.highlightItemId);
+      // Auto-scroll to the highlighted item after a short delay
+      setTimeout(() => {
+        const element = document.getElementById(`marketplace-${location.state.highlightItemId}`);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 500);
+      
+      // Clear the highlight after a few seconds
+      setTimeout(() => {
+        setHighlightedItemId(null);
+      }, 3000);
+    }
+  }, [location.state]);
 
   const handleCreateOffer = (offerData: Omit<MarketplaceOffer, 'id' | 'createdAt' | 'views' | 'likes' | 'comments' | 'seller'>) => {
     const newOffer: MarketplaceOffer = {
@@ -286,7 +331,21 @@ const MarketplacePage: React.FC = () => {
         verified: true
       }
     };
-    setOffers(prev => [newOffer, ...prev]);
+    
+    const updatedOffers = [newOffer, ...offers];
+    setOffers(updatedOffers);
+    
+    // Save to localStorage for homepage
+    try {
+      localStorage.setItem('marketplace_items', JSON.stringify(updatedOffers));
+      // Trigger storage event for HomePage to update
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'marketplace_items',
+        newValue: JSON.stringify(updatedOffers)
+      }));
+    } catch (error) {
+      console.error('Error saving marketplace data:', error);
+    }
   };
 
   const getConditionColor = (condition: string) => {
@@ -300,8 +359,8 @@ const MarketplacePage: React.FC = () => {
   };
 
   const filteredOffers = offers.filter(offer => {
-    const matchesSearch = offer.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         offer.description.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesSearch = offer.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                         offer.description.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesCategory = selectedCategory === 'all' || offer.category === selectedCategory;
     const matchesPrice = (!priceRange.min || offer.price >= parseFloat(priceRange.min)) &&
                         (!priceRange.max || offer.price <= parseFloat(priceRange.max));
@@ -353,8 +412,8 @@ const MarketplacePage: React.FC = () => {
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400" size={16} />
               <input
                 type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
                 className="w-full pl-9 pr-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500 text-responsive-sm"
                 placeholder={t('marketplace.searchPlaceholder')}
               />
@@ -438,9 +497,10 @@ const MarketplacePage: React.FC = () => {
         {filteredOffers.map(offer => (
           <div 
             key={offer.id} 
+            id={`marketplace-${offer.id}`}
             className={`simple-tile hover:border-slate-600 transition-all duration-200 overflow-hidden ${
               viewMode === 'list' ? 'flex flex-col sm:flex-row' : ''
-            }`}
+            } ${highlightedItemId === offer.id ? 'border-2 border-blue-500' : ''}`}
           >
             <div className={`${viewMode === 'list' ? 'w-full sm:w-40 lg:w-48 flex-shrink-0 aspect-video sm:aspect-square' : 'aspect-video'} bg-slate-700 relative`}>
               <div className="absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
Enhance homepage cards to display richer content previews (images, latest posts) and enable direct navigation with highlighting to the full posts/items.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d761672-9ab1-4dc1-931d-95ae337e19c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d761672-9ab1-4dc1-931d-95ae337e19c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>