### PR TITLE
Kompakter event karten layout anpassen

### DIFF
--- a/src/components/EventFeedWidget.tsx
+++ b/src/components/EventFeedWidget.tsx
@@ -182,13 +182,23 @@ const EventCard: React.FC<EventCardProps> = ({ event, leaderboard, timeRemaining
               <Users className="w-3 h-3 sm:w-4 sm:h-4 text-cyan-400" />
               <span className="text-slate-300">{event.participants} {t('events.participants')}</span>
             </div>
-            <Link 
-              to="/events" 
-              className="flex items-center gap-1 text-green-400 hover:text-green-300 transition-colors"
-            >
-              <span>{t('events.join')}</span>
-              <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4" />
-            </Link>
+            
+            {/* Interaction Bar - Compact between participants and join */}
+            <div className="flex items-center gap-2">
+              <InteractionBar 
+                contentType="event"
+                contentId={event.id}
+                showComments={false}
+                compact={true}
+              />
+              <Link 
+                to="/events" 
+                className="flex items-center gap-1 text-green-400 hover:text-green-300 transition-colors ml-2"
+              >
+                <span>{t('events.join')}</span>
+                <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4" />
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -242,16 +252,6 @@ const EventCard: React.FC<EventCardProps> = ({ event, leaderboard, timeRemaining
             </div>
           )}
         </div>
-      </div>
-
-      {/* Interaction Bar - Compact like FanArt cards */}
-      <div className="mt-2 pt-2 border-t border-slate-600/30">
-        <InteractionBar 
-          contentType="event"
-          contentId={event.id}
-          showComments={false}
-          compact={true}
-        />
       </div>
     </div>
   )


### PR DESCRIPTION
Move and compact `InteractionBar` in `EventCard` to reduce vertical space and match FanArt card layout.

Previously, the interaction bar occupied a separate section at the bottom of the card. This PR integrates it into the line containing participants and the join button, optimizing horizontal space and eliminating the need for an extra row.

---
<a href="https://cursor.com/background-agent?bcId=bc-690d37b2-f1c2-4d2d-b041-d60d02fc5ee3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-690d37b2-f1c2-4d2d-b041-d60d02fc5ee3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>