### PR TITLE
Event display layout and counts adjustment

### DIFF
--- a/src/components/EventFeedWidget.tsx
+++ b/src/components/EventFeedWidget.tsx
@@ -188,7 +188,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, leaderboard, timeRemaining
               <InteractionBar 
                 contentType="event"
                 contentId={event.id}
-                showComments={false}
+                showComments={true}
                 compact={true}
               />
               <Link 

--- a/src/components/InteractionComponents.tsx
+++ b/src/components/InteractionComponents.tsx
@@ -276,8 +276,78 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
   showComments = true,
   compact = false
 }) => {
-  const interactionData = useInteraction().getInteractionData(contentType, contentId)
+  const { getInteractionData } = useInteraction()
+  const { t } = useLanguage()
+  const [showCommentsSection, setShowCommentsSection] = useState(false)
+  
+  const interactionData = getInteractionData(contentType, contentId)
 
+  if (compact) {
+    // Compact mode for events - show like, saw, comment with numbers
+    return (
+      <div className={`flex items-center gap-2 sm:gap-3 ${className}`}>
+        {/* Like Button with count */}
+        <div className="flex items-center gap-1">
+          <LikeButton 
+            contentType={contentType} 
+            contentId={contentId} 
+            compact={true} // Don't show number in button, we add it separately
+          />
+          <span className="text-xs text-slate-400">
+            {interactionData.likes > 0 ? interactionData.likes : '0'}
+          </span>
+        </div>
+        
+        {/* View Counter with count */}
+        <div className="flex items-center gap-1">
+          <ViewCounter 
+            contentType={contentType} 
+            contentId={contentId} 
+            compact={true} // Don't show number in component, we add it separately
+          />
+          <span className="text-xs text-slate-400">
+            {interactionData.views > 0 ? interactionData.views : '0'}
+          </span>
+        </div>
+        
+        {/* Comment Button with count */}
+        {showComments && (
+          <button
+            onClick={() => setShowCommentsSection(!showCommentsSection)}
+            className="flex items-center gap-1 text-slate-400 hover:text-slate-300 transition-colors"
+          >
+            <MessageCircle className="w-3 h-3" />
+            <span className="text-xs text-slate-400">
+              {interactionData.comments.length > 0 ? interactionData.comments.length : '0'}
+            </span>
+          </button>
+        )}
+        
+        {/* Comments Section - Positioned below the interaction bar */}
+        {showComments && showCommentsSection && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setShowCommentsSection(false)}>
+            <div className="bg-slate-800 rounded-lg p-4 border border-slate-600 max-w-md w-full max-h-96 overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-semibold text-slate-200">{t('interaction.comments')}</h3>
+                <button 
+                  onClick={() => setShowCommentsSection(false)}
+                  className="text-slate-400 hover:text-slate-300 text-xl"
+                >
+                  ×
+                </button>
+              </div>
+              <CommentSection 
+                contentType={contentType} 
+                contentId={contentId}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Full mode for other components
   return (
     <div className={`space-y-3 ${className}`}>
       {/* Action Buttons */}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add comment button and display interaction counts (likes, views, comments) for events to match FanArtPost design.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `InteractionBar` component was extended to support a `compact` mode that explicitly shows counts for likes, views, and comments, and includes a comment button that opens a modal. Previously, events used a `compact` mode that hid these details, and the comment functionality was explicitly disabled. This change aligns event interaction display with the user's desired consistent experience across different content types.

---
<a href="https://cursor.com/background-agent?bcId=bc-13cc7b44-d5b7-4458-9658-25415c96ddf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13cc7b44-d5b7-4458-9658-25415c96ddf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>