### PR TITLE
Fix event post like and saw buttons

### DIFF
--- a/src/components/EventFeedWidget.tsx
+++ b/src/components/EventFeedWidget.tsx
@@ -175,30 +175,31 @@ const EventCard: React.FC<EventCardProps> = ({ event, leaderboard, timeRemaining
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-2 sm:gap-3">
-                  {/* Event Stats */}
-          <div className="space-y-1 sm:space-y-2">
+        {/* Event Stats */}
+        <div className="space-y-1 sm:space-y-2">
           <div className="flex items-center justify-between text-xs sm:text-sm">
             <div className="flex items-center gap-1 sm:gap-2">
               <Users className="w-3 h-3 sm:w-4 sm:h-4 text-cyan-400" />
               <span className="text-slate-300">{event.participants} {t('events.participants')}</span>
             </div>
             
-            {/* Interaction Bar - Compact between participants and join */}
-            <div className="flex items-center gap-2">
-              <InteractionBar 
-                contentType="event"
-                contentId={event.id}
-                showComments={true}
-                compact={true}
-              />
-              <Link 
-                to="/events" 
-                className="flex items-center gap-1 text-green-400 hover:text-green-300 transition-colors ml-2"
-              >
-                <span>{t('events.join')}</span>
-                <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4" />
-              </Link>
-            </div>
+            <Link 
+              to="/events" 
+              className="flex items-center gap-1 text-green-400 hover:text-green-300 transition-colors"
+            >
+              <span>{t('events.join')}</span>
+              <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4" />
+            </Link>
+          </div>
+          
+          {/* Interaction Bar - Now positioned below participants */}
+          <div className="flex items-center justify-between pt-1">
+            <InteractionBar 
+              contentType="event"
+              contentId={event.id}
+              showComments={true}
+              compact={true}
+            />
           </div>
         </div>
 

--- a/src/components/InteractionComponents.tsx
+++ b/src/components/InteractionComponents.tsx
@@ -77,7 +77,7 @@ export const LikeButton: React.FC<LikeButtonProps> = ({
       } ${!user ? 'opacity-50 cursor-not-allowed' : 'hover:scale-105'} ${className}`}
       title={user ? (isLiked ? t('interaction.unlike') : t('interaction.like')) : t('interaction.loginToLike')}
     >
-      <Heart className={`${compact ? 'w-3 h-3' : 'w-4 h-4'} ${isLiked ? 'fill-current' : ''}`} />
+      <Heart className={`${compact ? 'w-3 h-3 sm:w-4 sm:h-4' : 'w-4 h-4'} ${isLiked ? 'fill-current scale-110' : ''} transition-all`} />
       {!compact && (
         <span className="text-xs sm:text-sm font-medium">
           {interactionData.likes > 0 ? interactionData.likes : ''}
@@ -110,7 +110,7 @@ export const ViewCounter: React.FC<ViewCounterProps> = ({
 
   return (
     <div className={`flex items-center gap-1 sm:gap-2 text-slate-400 ${className}`}>
-      <Eye className={compact ? 'w-3 h-3' : 'w-4 h-4'} />
+      <Eye className={`${compact ? 'w-3 h-3 sm:w-4 sm:h-4' : 'w-4 h-4'} transition-all`} />
       {!compact && (
         <span className="text-xs sm:text-sm">
           {interactionData.views > 0 ? interactionData.views : ''}
@@ -285,7 +285,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
   if (compact) {
     // Compact mode for events - show like, saw, comment with numbers
     return (
-      <div className={`flex items-center gap-2 sm:gap-3 ${className}`}>
+      <div className={`flex items-center gap-3 sm:gap-4 ${className}`}>
         {/* Like Button with count */}
         <div className="flex items-center gap-1">
           <LikeButton 
@@ -293,7 +293,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
             contentId={contentId} 
             compact={true} // Don't show number in button, we add it separately
           />
-          <span className="text-xs text-slate-400">
+          <span className="text-xs text-slate-400 font-medium">
             {interactionData.likes > 0 ? interactionData.likes : '0'}
           </span>
         </div>
@@ -305,7 +305,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
             contentId={contentId} 
             compact={true} // Don't show number in component, we add it separately
           />
-          <span className="text-xs text-slate-400">
+          <span className="text-xs text-slate-400 font-medium">
             {interactionData.views > 0 ? interactionData.views : '0'}
           </span>
         </div>
@@ -314,10 +314,10 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
         {showComments && (
           <button
             onClick={() => setShowCommentsSection(!showCommentsSection)}
-            className="flex items-center gap-1 text-slate-400 hover:text-slate-300 transition-colors"
+            className="flex items-center gap-1 text-slate-400 hover:text-blue-400 transition-colors"
           >
-            <MessageCircle className="w-3 h-3" />
-            <span className="text-xs text-slate-400">
+            <MessageCircle className="w-3 h-3 sm:w-4 sm:h-4" />
+            <span className="text-xs text-slate-400 font-medium">
               {interactionData.comments.length > 0 ? interactionData.comments.length : '0'}
             </span>
           </button>


### PR DESCRIPTION
Improve the layout and styling of interaction buttons on event cards to match the FanArt posts' appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f9ae284-b194-4ad7-94d4-8f053cca3f41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f9ae284-b194-4ad7-94d4-8f053cca3f41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>