### PR TITLE
Investigate heart position relative to zero

### DIFF
--- a/src/components/InteractionComponents.tsx
+++ b/src/components/InteractionComponents.tsx
@@ -282,42 +282,42 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
   const interactionData = getInteractionData(contentType, contentId)
 
   if (compact) {
-    // Compact mode for events - show like, saw, comment with numbers evenly spaced
+    // Compact mode for events - show like, saw, comment with numbers close together
     return (
-      <div className={`flex items-center justify-between w-full max-w-[200px] ${className}`}>
+      <div className={`flex items-center justify-center gap-6 w-full ${className}`}>
         {/* Like Button with count */}
-        <div className="flex items-center gap-0.5 min-w-0 flex-1 justify-center">
+        <div className="flex items-center gap-1">
           <LikeButton 
             contentType={contentType} 
             contentId={contentId} 
             compact={true}
           />
-          <span className="text-xs text-slate-400 font-medium ml-0.5">
+          <span className="text-xs text-slate-400 font-medium">
             {interactionData.likes > 0 ? interactionData.likes : '0'}
           </span>
         </div>
         
         {/* View Counter with count */}
-        <div className="flex items-center gap-0.5 min-w-0 flex-1 justify-center">
+        <div className="flex items-center gap-1">
           <ViewCounter 
             contentType={contentType} 
             contentId={contentId} 
             compact={true}
           />
-          <span className="text-xs text-slate-400 font-medium ml-0.5">
+          <span className="text-xs text-slate-400 font-medium">
             {interactionData.views > 0 ? interactionData.views : '0'}
           </span>
         </div>
         
         {/* Comment Button with count */}
         {showComments && (
-          <div className="flex items-center gap-0.5 min-w-0 flex-1 justify-center">
+          <div className="flex items-center gap-1">
             <button
               onClick={() => setShowCommentsSection(!showCommentsSection)}
-              className="flex items-center gap-0.5 text-slate-400 hover:text-blue-400 transition-colors"
+              className="flex items-center gap-1 text-slate-400 hover:text-blue-400 transition-colors"
             >
               <MessageCircle className="w-4 h-4 sm:w-5 sm:h-5" />
-              <span className="text-xs text-slate-400 font-medium ml-0.5">
+              <span className="text-xs text-slate-400 font-medium">
                 {interactionData.comments.length > 0 ? interactionData.comments.length : '0'}
               </span>
             </button>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adjust spacing in `InteractionBar` compact mode to bring icons and counts closer together.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous layout used `flex-1` and `justify-center` for each icon section, which caused icons (like the heart) and their counts (like '0') to be spread out excessively. This change centers the icon groups and uses consistent smaller gaps to improve readability and compactness.

---
<a href="https://cursor.com/background-agent?bcId=bc-fca0dd87-8b21-4f9b-867f-45abef6afe1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fca0dd87-8b21-4f9b-867f-45abef6afe1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>