### PR TITLE
Fix spacing for likes and comments

### DIFF
--- a/src/components/InteractionComponents.tsx
+++ b/src/components/InteractionComponents.tsx
@@ -284,9 +284,9 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
   if (compact) {
     // Compact mode for events - show like, saw, comment with numbers close together
     return (
-      <div className={`flex items-center justify-center gap-6 w-full ${className}`}>
+      <div className={`flex items-center justify-center gap-1 w-full ${className}`}>
         {/* Like Button with count */}
-        <div className="flex items-center gap-1">
+        <div className="flex items-center">
           <LikeButton 
             contentType={contentType} 
             contentId={contentId} 
@@ -298,7 +298,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
         </div>
         
         {/* View Counter with count */}
-        <div className="flex items-center gap-1">
+        <div className="flex items-center">
           <ViewCounter 
             contentType={contentType} 
             contentId={contentId} 
@@ -311,7 +311,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
         
         {/* Comment Button with count */}
         {showComments && (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center">
             <button
               onClick={() => setShowCommentsSection(!showCommentsSection)}
               className="text-slate-400 hover:text-blue-400 transition-colors"


### PR DESCRIPTION
Adjust spacing in the compact InteractionBar to display icons and numbers closer together as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d763a81-af0e-476a-9285-bf816a9c17e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d763a81-af0e-476a-9285-bf816a9c17e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>