### PR TITLE
Align spacing for like, saw, and comment counts

### DIFF
--- a/src/components/InteractionComponents.tsx
+++ b/src/components/InteractionComponents.tsx
@@ -287,11 +287,27 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
       <div className={`flex items-center gap-4 ${className}`}>
         {/* Like Button with count */}
         <div className="flex items-center gap-1">
-          <LikeButton 
-            contentType={contentType} 
-            contentId={contentId} 
-            compact={true}
-          />
+          <button
+            onClick={async () => {
+              const { likeContent, unlikeContent, hasUserLiked } = useInteraction()
+              const { user } = useUser()
+              if (!user) return
+              
+              const isLiked = hasUserLiked(contentType, contentId, user.id)
+              try {
+                if (isLiked) {
+                  await unlikeContent(contentType, contentId, user.id)
+                } else {
+                  await likeContent(contentType, contentId, user.id)
+                }
+              } catch (error) {
+                console.error('Error toggling like:', error)
+              }
+            }}
+            className="text-slate-400 hover:text-pink-400 transition-colors"
+          >
+            <Heart className="w-4 h-4" />
+          </button>
           <span className="text-xs text-slate-400 font-medium">
             {interactionData.likes > 0 ? interactionData.likes : '0'}
           </span>
@@ -299,11 +315,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
         
         {/* View Counter with count */}
         <div className="flex items-center gap-1">
-          <ViewCounter 
-            contentType={contentType} 
-            contentId={contentId} 
-            compact={true}
-          />
+          <Eye className="w-4 h-4 text-slate-400" />
           <span className="text-xs text-slate-400 font-medium">
             {interactionData.views > 0 ? interactionData.views : '0'}
           </span>


### PR DESCRIPTION
```pr_request_template
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure consistent icon-to-count spacing for like, view, and comment features.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation using `LikeButton` and `ViewCounter` components in compact mode resulted in inconsistent spacing between the icon and its corresponding count. This change directly renders the icons and counts within a `gap-1` container, aligning the spacing with the comment feature.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-e41c9cdc-0be3-46b7-888d-6ad576d7af76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e41c9cdc-0be3-46b7-888d-6ad576d7af76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>