### PR TITLE
Fix ranking placeholders on homepage and profile

### DIFF
--- a/src/translations/ar.ts
+++ b/src/translations/ar.ts
@@ -780,6 +780,15 @@ const ar = {
   'rank.nextRank': 'الترتيب التالي',
   'rank.maxRank': 'تم الوصول للترتيب الأقصى',
 
+  // Rank Titles - ألقاب الترتيب
+  'rank.n64Beginner': 'مبتدئ N64',
+  'rank.moduleCollector': 'جامع الوحدات',
+  'rank.retroGeek': 'مهووس الألعاب القديمة',
+  'rank.speedrunner': 'عداء السرعة',
+  'rank.fanartMaster': 'سيد الفن الجماهيري',
+  'rank.retroChampion': 'بطل الألعاب القديمة',
+  'rank.n64Legend': 'أسطورة N64',
+
   // Profile activity - نشاط الملف الشخصي
   'profile.activityHistory': 'تاريخ النشاط',
   'profile.achievedOn': 'تم تحقيقه في',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -672,6 +672,15 @@ const de = {
   'rank.current': 'Aktuell',
   'rank.nextRank': 'Nächster Rang',
   'rank.maxRank': 'Maximaler Rang erreicht',
+
+  // Rank Titles
+  'rank.n64Beginner': 'N64 Anfänger',
+  'rank.moduleCollector': 'Modul Sammler',
+  'rank.retroGeek': 'Retro Geek',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Fanart Meister',
+  'rank.retroChampion': 'Retro Champion',
+  'rank.n64Legend': 'N64 Legende',
   'profile.activityHistory': 'Aktivitätsverlauf',
   'profile.achievedOn': 'Erreicht am',
   'profile.medals.title': 'Medaillen',

--- a/src/translations/el.ts
+++ b/src/translations/el.ts
@@ -730,6 +730,15 @@ const el = {
   'rank.nextRank': 'Επόμενη Κατάταξη',
   'rank.maxRank': 'Μέγιστη κατάταξη επιτεύχθηκε',
 
+  // Rank Titles
+  'rank.n64Beginner': 'N64 Αρχάριος',
+  'rank.moduleCollector': 'Συλλέκτης Μονάδων',
+  'rank.retroGeek': 'Ρετρό Geek',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Δάσκαλος Fanart',
+  'rank.retroChampion': 'Ρετρό Πρωταθλητής',
+  'rank.n64Legend': 'N64 Θρύλος',
+
   // Medals
   'medal.season': 'Σεζόν',
   'medal.bonusXP': 'Bonus XP',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -672,6 +672,15 @@ const en = {
   'rank.current': 'Current',
   'rank.nextRank': 'Next Rank',
   'rank.maxRank': 'Maximum rank reached',
+
+  // Rank Titles
+  'rank.n64Beginner': 'N64 Beginner',
+  'rank.moduleCollector': 'Module Collector',
+  'rank.retroGeek': 'Retro Geek',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Fanart Master',
+  'rank.retroChampion': 'Retro Champion',
+  'rank.n64Legend': 'N64 Legend',
   'profile.activityHistory': 'Activity History',
   'profile.achievedOn': 'Achieved on',
   'profile.medals.title': 'Medals',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -717,6 +717,15 @@ const es = {
   'rank.nextRank': 'Siguiente Rango',
   'rank.maxRank': 'Rango máximo alcanzado',
 
+  // Rank Titles
+  'rank.n64Beginner': 'Principiante N64',
+  'rank.moduleCollector': 'Coleccionista de Módulos',
+  'rank.retroGeek': 'Geek Retro',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Maestro Fanart',
+  'rank.retroChampion': 'Campeón Retro',
+  'rank.n64Legend': 'Leyenda N64',
+
   // Medal
   'medal.season': 'Temporada',
   'medal.bonusXP': 'XP Bonus',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -672,6 +672,15 @@ const fr = {
   'rank.current': 'Actuel',
   'rank.nextRank': 'Prochain Rang',
   'rank.maxRank': 'Rang maximum atteint',
+
+  // Rank Titles
+  'rank.n64Beginner': 'Débutant N64',
+  'rank.moduleCollector': 'Collectionneur de Modules',
+  'rank.retroGeek': 'Geek Rétro',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Maître Fanart',
+  'rank.retroChampion': 'Champion Rétro',
+  'rank.n64Legend': 'Légende N64',
   'profile.activityHistory': 'Historique d\'Activité',
   'profile.achievedOn': 'Obtenu le',
   'profile.medals.title': 'Médailles',

--- a/src/translations/hi.ts
+++ b/src/translations/hi.ts
@@ -672,6 +672,15 @@ const hi = {
   'rank.current': 'वर्तमान',
   'rank.nextRank': 'अगली रैंक',
   'rank.maxRank': 'अधिकतम रैंक पहुंच गई',
+
+  // Rank Titles
+  'rank.n64Beginner': 'N64 शुरुआती',
+  'rank.moduleCollector': 'मॉड्यूल कलेक्टर',
+  'rank.retroGeek': 'रेट्रो गीक',
+  'rank.speedrunner': 'स्पीडरनर',
+  'rank.fanartMaster': 'फैनआर्ट मास्टर',
+  'rank.retroChampion': 'रेट्रो चैंपियन',
+  'rank.n64Legend': 'N64 लीजेंड',
   'profile.activityHistory': 'गतिविधि इतिहास',
   'profile.achievedOn': 'पर हासिल किया',
   'profile.medals.title': 'मेडल',

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -674,6 +674,15 @@ const it = {
   'rank.current': 'Attuale',
   'rank.nextRank': 'Prossimo Rango',
   'rank.maxRank': 'Rango massimo raggiunto',
+
+  // Rank Titles
+  'rank.n64Beginner': 'Principiante N64',
+  'rank.moduleCollector': 'Collezionista di Moduli',
+  'rank.retroGeek': 'Geek Retrò',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Maestro Fanart',
+  'rank.retroChampion': 'Campione Retrò',
+  'rank.n64Legend': 'Leggenda N64',
   'profile.activityHistory': 'Cronologia Attività',
   'profile.achievedOn': 'Ottenuto il',
   'profile.medals.title': 'Medaglie',

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -667,6 +667,15 @@ const ja = {
   'rank.nextRank': '次のランク',
   'rank.maxRank': '最高ランクに到達',
 
+  // Rank Titles
+  'rank.n64Beginner': 'N64初心者',
+  'rank.moduleCollector': 'モジュールコレクター',
+  'rank.retroGeek': 'レトロギーク',
+  'rank.speedrunner': 'スピードランナー',
+  'rank.fanartMaster': 'ファンアートマスター',
+  'rank.retroChampion': 'レトロチャンピオン',
+  'rank.n64Legend': 'N64レジェンド',
+
   // Medal system
   'medal.season': 'シーズン',
   'medal.bonusXP': 'ボーナスXP',

--- a/src/translations/ko.ts
+++ b/src/translations/ko.ts
@@ -672,6 +672,15 @@ const ko = {
   'rank.current': '현재',
   'rank.nextRank': '다음 랭크',
   'rank.maxRank': '최대 랭크 달성',
+
+  // Rank Titles
+  'rank.n64Beginner': 'N64 초보자',
+  'rank.moduleCollector': '모듈 수집가',
+  'rank.retroGeek': '레트로 긱',
+  'rank.speedrunner': '스피드러너',
+  'rank.fanartMaster': '팬아트 마스터',
+  'rank.retroChampion': '레트로 챔피언',
+  'rank.n64Legend': 'N64 전설',
   'profile.activityHistory': '활동 히스토리',
   'profile.achievedOn': '달성일',
   'profile.medals.title': '메달',

--- a/src/translations/pt.ts
+++ b/src/translations/pt.ts
@@ -672,6 +672,15 @@ const pt = {
   'rank.current': 'Atual',
   'rank.nextRank': 'Próxima Classificação',
   'rank.maxRank': 'Classificação máxima alcançada',
+
+  // Rank Titles
+  'rank.n64Beginner': 'Iniciante N64',
+  'rank.moduleCollector': 'Colecionador de Módulos',
+  'rank.retroGeek': 'Geek Retrô',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Mestre Fanart',
+  'rank.retroChampion': 'Campeão Retrô',
+  'rank.n64Legend': 'Lenda N64',
   'profile.activityHistory': 'Histórico de Atividades',
   'profile.achievedOn': 'Conquistado em',
   'profile.medals.title': 'Medalhas',

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -655,6 +655,15 @@ const ru = {
   'rank.current': 'Current',
   'rank.nextRank': 'Next Rank',
   'rank.maxRank': 'Maximum rank reached',
+
+  // Rank Titles
+  'rank.n64Beginner': 'N64 Новичок',
+  'rank.moduleCollector': 'Коллекционер Модулей',
+  'rank.retroGeek': 'Ретро Гик',
+  'rank.speedrunner': 'Спидраннер',
+  'rank.fanartMaster': 'Мастер Фанарта',
+  'rank.retroChampion': 'Ретро Чемпион',
+  'rank.n64Legend': 'N64 Легенда',
   'profile.activityHistory': 'Activity History',
   'profile.achievedOn': 'Achieved on',
   'profile.medals.title': 'Medals',

--- a/src/translations/tr.ts
+++ b/src/translations/tr.ts
@@ -672,6 +672,15 @@ const tr = {
   'rank.current': 'Current',
   'rank.nextRank': 'Next Rank',
   'rank.maxRank': 'Maximum rank reached',
+
+  // Rank Titles
+  'rank.n64Beginner': 'N64 Yeni Başlayan',
+  'rank.moduleCollector': 'Modül Koleksiyoncusu',
+  'rank.retroGeek': 'Retro Geek',
+  'rank.speedrunner': 'Speedrunner',
+  'rank.fanartMaster': 'Fanart Ustası',
+  'rank.retroChampion': 'Retro Şampiyon',
+  'rank.n64Legend': 'N64 Efsanesi',
   'profile.activityHistory': 'Activity History',
   'profile.achievedOn': 'Achieved on',
   'profile.medals.title': 'Medals',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -743,6 +743,15 @@ const zh = {
   'rank.nextRank': '下一级别',
   'rank.maxRank': '已达到最高级别',
 
+  // Rank Titles
+  'rank.n64Beginner': 'N64初学者',
+  'rank.moduleCollector': '模块收集者',
+  'rank.retroGeek': '复古极客',
+  'rank.speedrunner': '速通玩家',
+  'rank.fanartMaster': '同人艺术大师',
+  'rank.retroChampion': '复古冠军',
+  'rank.n64Legend': 'N64传奇',
+
   // Medal
   'medal.season': '赛季',
   'medal.bonusXP': '奖励经验',


### PR DESCRIPTION
Add missing rank title translations to resolve placeholder text in the ranking system.

Previously, specific rank titles (e.g., "N64 Beginner") were not translated across all 14 languages, leading to placeholder text like "something.something" being displayed. This PR adds the correct translations for these rank titles, ensuring the ranking system is fully localized on the homepage and profile.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fd7d7d2-c0ba-4bf4-8cea-f7243e75ede1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fd7d7d2-c0ba-4bf4-8cea-f7243e75ede1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>