### PR TITLE
Replace ranking card with fixed cp loading bar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useState, useEffect } from 'react'
 import Sidebar from './Sidebar'
+import RankingBar from './RankingBar'
 import { useUser } from '../contexts/UserContext'
 import { usePoints } from '../contexts/PointsContext'
 import { useLanguage } from '../contexts/LanguageContext'
@@ -148,6 +149,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           </div>
         </Link>
       )}
+
+      {/* Ranking Bar - Fixed between sidebar and user icons */}
+      <RankingBar />
 
       <Sidebar isOpen={isMobileSidebarOpen} onClose={closeMobileSidebar} />
       

--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { useUser } from '../contexts/UserContext'
+import { usePoints } from '../contexts/PointsContext'
+import { useLanguage } from '../contexts/LanguageContext'
+import { Trophy } from 'lucide-react'
+
+const RankingBar: React.FC = () => {
+  const { user, isAuthenticated } = useUser()
+  const { getUserPosition, userPoints } = usePoints()
+  const { t } = useLanguage()
+
+  if (!isAuthenticated || !user || !userPoints) {
+    return null
+  }
+
+  const currentRank = getUserPosition(user.id, { type: 'global', timeframe: 'allTime' })
+  const progressPercentage = Math.min(((user.xp || 0) % 1000) / 10, 100)
+
+  return (
+    <div className="fixed z-40 flex items-center gap-2 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
+         style={{
+           top: 'clamp(0.5rem, 2vw, 1rem)',
+           left: '50%',
+           transform: 'translateX(-50%)',
+           padding: 'clamp(0.5rem, 1.5vw, 0.75rem)',
+           minWidth: 'clamp(200px, 30vw, 280px)',
+           maxWidth: 'clamp(280px, 40vw, 350px)'
+         }}>
+      
+      {/* Rank Badge */}
+      <div className="flex items-center gap-1 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-2 py-1">
+        <Trophy className="text-yellow-400" style={{ width: 'clamp(12px, 2.5vw, 16px)', height: 'clamp(12px, 2.5vw, 16px)' }} />
+        <span className="font-medium text-yellow-100" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
+          #{currentRank || 'N/A'}
+        </span>
+      </div>
+
+      {/* Progress Bar Container */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-slate-300" style={{ fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)' }}>
+            {t('ranking.rankProgress')}
+          </span>
+          <span className="text-slate-400" style={{ fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)' }}>
+            {Math.min(((user.xp || 0) % 1000), 1000)}/1000 XP
+          </span>
+        </div>
+        
+        {/* Progress Bar */}
+        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(4px, 1vw, 6px)' }}>
+          <div 
+            className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-full transition-all duration-300"
+            style={{ 
+              width: `${progressPercentage}%`,
+              height: '100%'
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Points Display */}
+      <div className="flex items-center gap-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-2 py-1">
+        <span className="font-medium text-blue-100" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
+          {userPoints.totalPoints.toLocaleString()} CP
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default RankingBar

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,7 +12,6 @@ import SingleFanArtCard from '../components/SingleFanArtCard'
 import SingleMediaCard from '../components/SingleMediaCard'
 import SingleRecordCard from '../components/SingleRecordCard'
 import SingleMarketplaceCard from '../components/SingleMarketplaceCard'
-import { Trophy } from 'lucide-react'
 
 interface ForumThread {
   id: string
@@ -95,7 +94,6 @@ const HomePage: React.FC = () => {
   const { user } = useUser()
   const { t, currentLanguage } = useLanguage()
   const { threads, posts } = useForum()
-  const { getUserPosition } = usePoints()
 
   // Load FanArt data from localStorage or use mock data
   const [fanArtItems, setFanArtItems] = useState<FanArtItem[]>([])
@@ -289,63 +287,7 @@ const HomePage: React.FC = () => {
         </SafeComponent>
       )}
 
-      {/* USER RANKING SECTION */}
-      {user && (
-        <SafeComponent name="UserRanking">
-          <div className="mb-responsive responsive-max-width">
-            <div className="simple-tile p-4 sm:p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-responsive-lg font-bold text-slate-100">
-                  {t('home.yourRanking')}
-                </h3>
-                <Trophy className="w-6 h-6 text-yellow-400" />
-              </div>
-              
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                {/* Current Rank */}
-                <div className="text-center p-4 bg-gradient-to-br from-yellow-500/20 to-amber-500/20 rounded-lg border border-yellow-400/30">
-                  <div className="text-2xl font-bold text-yellow-400 mb-1">
-                    #{getUserPosition(user.id, { type: 'global', timeframe: 'allTime' }) || 'N/A'}
-                  </div>
-                  <div className="text-sm text-slate-300">{t('ranking.globalRank')}</div>
-                </div>
-                
-                {/* Total Points */}
-                <div className="text-center p-4 bg-gradient-to-br from-blue-500/20 to-purple-500/20 rounded-lg border border-blue-400/30">
-                  <div className="text-2xl font-bold text-blue-400 mb-1">
-                    {user.xp?.toLocaleString() || '0'}
-                  </div>
-                  <div className="text-sm text-slate-300">{t('ranking.totalPoints')}</div>
-                </div>
-                
-                {/* Current Level */}
-                <div className="text-center p-4 bg-gradient-to-br from-green-500/20 to-emerald-500/20 rounded-lg border border-green-400/30">
-                  <div className="text-2xl font-bold text-green-400 mb-1">
-                    {user.level || 1}
-                  </div>
-                  <div className="text-sm text-slate-300">{t('ranking.currentLevel')}</div>
-                </div>
-              </div>
-              
-              {/* Rank Progress */}
-              <div className="mt-4 p-4 bg-slate-700/30 rounded-lg">
-                <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm text-slate-300">{t('ranking.rankProgress')}</span>
-                  <span className="text-sm text-slate-400">
-                    {Math.min(((user.xp || 0) % 1000), 1000)}/1000 XP
-                  </span>
-                </div>
-                <div className="w-full bg-slate-600 rounded-full h-2">
-                  <div 
-                    className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all duration-300"
-                    style={{ width: `${Math.min(((user.xp || 0) % 1000) / 10, 100)}%` }}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </SafeComponent>
-      )}
+
 
       {/* NEWS CARDS SECTION */}
       <div className="space-y-6">


### PR DESCRIPTION
Remove the ranking card from the homepage and replace it with a compact, fixed ranking bar in the top navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e4e1a8a-5619-47e9-b47e-33c66291f7f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e4e1a8a-5619-47e9-b47e-33c66291f7f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>