### PR TITLE
Fix ranking bar overlap on built #259

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -99,7 +99,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       {/* Mobile menu button */}
       <button
         onClick={toggleMobileSidebar}
-        className="mobile-menu-button fixed z-45 lg:hidden bg-slate-800/90 backdrop-blur-sm text-white rounded-lg shadow-lg hover:bg-slate-700 transition-all duration-200 border border-slate-600 flex items-center justify-center"
+        className="mobile-menu-button fixed z-50 lg:hidden bg-slate-800/90 backdrop-blur-sm text-white rounded-lg shadow-lg hover:bg-slate-700 transition-all duration-200 border border-slate-600 flex items-center justify-center"
         style={{
           top: 'clamp(0.5rem, 2vw, 1rem)',
           left: 'clamp(0.5rem, 2vw, 1rem)',
@@ -128,7 +128,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       {isAuthenticated && user && (
         <Link 
           to="/profile" 
-          className="fixed z-45 flex items-center justify-center rounded-full bg-slate-800/90 backdrop-blur-sm hover:bg-slate-700/90 transition-all duration-200 border border-slate-600 shadow-lg group"
+          className="fixed z-50 flex items-center justify-center rounded-full bg-slate-800/90 backdrop-blur-sm hover:bg-slate-700/90 transition-all duration-200 border border-slate-600 shadow-lg group"
           style={{
             top: 'clamp(0.5rem, 2vw, 1rem)',
             right: 'clamp(0.5rem, 2vw, 1rem)',

--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -17,48 +17,37 @@ const RankingBar: React.FC = () => {
   const progressPercentage = Math.min(((user.xp || 0) % 1000) / 10, 100)
 
   return (
-    <div className="ranking-bar-container fixed z-40 flex items-center gap-1 sm:gap-2 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
+    <div className="fixed z-40 flex items-center gap-3 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
          style={{
            top: 'clamp(0.5rem, 2vw, 1rem)',
-           // Position between the mobile menu button and user icon
-           left: 'clamp(70px, 15vw, 90px)', // Start after mobile menu button
-           right: 'clamp(70px, 15vw, 90px)', // End before user icon
-           height: 'clamp(44px, 10vw, 52px)', // Match sidebar and user icon height exactly
-           padding: 'clamp(0.25rem, 1vw, 0.5rem)',
-           // Dynamic width - will fill available space between icons
-           width: 'auto',
-           maxWidth: 'calc(100vw - clamp(140px, 30vw, 180px))' // Total space for both side icons
+           left: '50%',
+           transform: 'translateX(-50%)',
+           padding: 'clamp(0.5rem, 1.5vw, 0.75rem)',
+           minWidth: 'clamp(200px, 30vw, 280px)',
+           maxWidth: 'clamp(280px, 40vw, 350px)'
          }}>
       
-      {/* Rank Badge - Compact */}
-      <div className="flex items-center gap-0.5 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-1 py-0.5 flex-shrink-0">
-        <Trophy className="text-yellow-400 hidden xs:block" style={{ width: 'clamp(10px, 2vw, 14px)', height: 'clamp(10px, 2vw, 14px)' }} />
-        <span className="font-medium text-yellow-100 whitespace-nowrap" style={{ fontSize: 'clamp(0.625rem, 1.4vw, 0.75rem)' }}>
+      {/* Rank Badge */}
+      <div className="flex items-center gap-1 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-2 py-1 flex-shrink-0">
+        <Trophy className="text-yellow-400" style={{ width: 'clamp(12px, 2.5vw, 16px)', height: 'clamp(12px, 2.5vw, 16px)' }} />
+        <span className="font-medium text-yellow-100" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
           #{currentRank || 'N/A'}
         </span>
       </div>
 
-      {/* Progress Bar Container - Optimized for smaller space */}
-      <div className="flex-1 min-w-0 px-1">
-        {/* Show progress info on very small screens as single line */}
-        <div className="hidden sm:flex items-center justify-between mb-0.5">
-          <span className="text-slate-300 whitespace-nowrap truncate" style={{ fontSize: 'clamp(0.5rem, 1.2vw, 0.625rem)' }}>
+      {/* Progress Bar Container */}
+      <div className="flex-1 min-w-0 mx-2">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-slate-300" style={{ fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)' }}>
             {t('ranking.rankProgress')}
           </span>
-          <span className="text-slate-400 whitespace-nowrap" style={{ fontSize: 'clamp(0.5rem, 1.2vw, 0.625rem)' }}>
+          <span className="text-slate-400" style={{ fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)' }}>
             {Math.min(((user.xp || 0) % 1000), 1000)}/1000 XP
           </span>
         </div>
         
-        {/* Compact single line for mobile */}
-        <div className="sm:hidden flex items-center justify-center mb-0.5">
-          <span className="text-slate-300 text-center" style={{ fontSize: 'clamp(0.5rem, 1.2vw, 0.625rem)' }}>
-            {Math.min(((user.xp || 0) % 1000), 1000)}/1000 XP
-          </span>
-        </div>
-        
-        {/* Progress Bar - Thinner for compact layout */}
-        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(3px, 0.8vw, 4px)' }}>
+        {/* Progress Bar */}
+        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(4px, 1vw, 6px)' }}>
           <div 
             className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-full transition-all duration-300"
             style={{ 
@@ -69,9 +58,9 @@ const RankingBar: React.FC = () => {
         </div>
       </div>
 
-      {/* Points Display - Compact */}
-      <div className="flex items-center bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-1 py-0.5 flex-shrink-0">
-        <span className="font-medium text-blue-100 whitespace-nowrap" style={{ fontSize: 'clamp(0.625rem, 1.4vw, 0.75rem)' }}>
+      {/* Points Display */}
+      <div className="flex items-center gap-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-2 py-1 flex-shrink-0">
+        <span className="font-medium text-blue-100" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
           {userPoints.totalPoints.toLocaleString()} CP
         </span>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -976,25 +976,7 @@ code {
   @apply text-center text-xs sm:text-sm lg:text-base;
 }
 
-/* Z-index utilities */
-.z-45 {
-  z-index: 45;
-}
 
-/* Extra small screen utility */
-@media (min-width: 475px) {
-  .xs\:block {
-    display: block;
-  }
-}
-
-/* Very small screen adjustments */
-@media (max-width: 360px) {
-  /* Hide ranking bar on very small screens to prevent overlaps */
-  .ranking-bar-container {
-    display: none !important;
-  }
-}
 
 /* Navigation Styles - Fully Responsive */
 .sidebar {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Revert RankingBar to build #259 and adjust spacing to prevent overlapping points and CP.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous complex responsive layout for the ranking bar caused overlapping issues with the points and CP display. This PR reverts to the simpler, centered positioning from build #259 and adds minor spacing adjustments to ensure elements no longer overlap, while also cleaning up related CSS and z-index changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-41e8f50d-883b-4e8a-a3d3-009d5826646c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41e8f50d-883b-4e8a-a3d3-009d5826646c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>