### PR TITLE
Abstand in Ranking-Leiste korrigieren

### DIFF
--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -17,37 +17,37 @@ const RankingBar: React.FC = () => {
   const progressPercentage = Math.min(((user.xp || 0) % 1000) / 10, 100)
 
   return (
-    <div className="fixed z-40 flex items-center gap-3 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
+    <div className="fixed z-40 flex items-center gap-1 sm:gap-3 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
          style={{
            top: 'clamp(0.5rem, 2vw, 1rem)',
            left: '50%',
            transform: 'translateX(-50%)',
-           padding: 'clamp(0.5rem, 1.5vw, 0.75rem)',
-           minWidth: 'clamp(200px, 30vw, 280px)',
+           padding: 'clamp(0.375rem, 1.5vw, 0.75rem)',
+           minWidth: 'clamp(180px, 30vw, 280px)',
            maxWidth: 'clamp(280px, 40vw, 350px)'
          }}>
       
       {/* Rank Badge */}
-      <div className="flex items-center gap-1 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-2 py-1 flex-shrink-0">
-        <Trophy className="text-yellow-400" style={{ width: 'clamp(12px, 2.5vw, 16px)', height: 'clamp(12px, 2.5vw, 16px)' }} />
-        <span className="font-medium text-yellow-100" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
+      <div className="flex items-center gap-1 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-1.5 sm:px-2 py-1 flex-shrink-0">
+        <Trophy className="text-yellow-400" style={{ width: 'clamp(10px, 2.5vw, 16px)', height: 'clamp(10px, 2.5vw, 16px)' }} />
+        <span className="font-medium text-yellow-100" style={{ fontSize: 'clamp(0.7rem, 1.8vw, 0.875rem)' }}>
           #{currentRank || 'N/A'}
         </span>
       </div>
 
       {/* Progress Bar Container */}
-      <div className="flex-1 min-w-0 mx-2">
+      <div className="flex-1 min-w-0 mx-1 sm:mx-2">
         <div className="flex items-center justify-between mb-1">
-          <span className="text-slate-300" style={{ fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)' }}>
+          <span className="text-slate-300" style={{ fontSize: 'clamp(0.6rem, 1.5vw, 0.75rem)' }}>
             {t('ranking.rankProgress')}
           </span>
-          <span className="text-slate-400" style={{ fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)' }}>
+          <span className="text-slate-400" style={{ fontSize: 'clamp(0.6rem, 1.5vw, 0.75rem)' }}>
             {Math.min(((user.xp || 0) % 1000), 1000)}/1000 XP
           </span>
         </div>
         
         {/* Progress Bar */}
-        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(4px, 1vw, 6px)' }}>
+        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(3px, 1vw, 6px)' }}>
           <div 
             className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-full transition-all duration-300"
             style={{ 
@@ -59,8 +59,8 @@ const RankingBar: React.FC = () => {
       </div>
 
       {/* Points Display */}
-      <div className="flex items-center gap-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-2 py-1 flex-shrink-0">
-        <span className="font-medium text-blue-100" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
+      <div className="flex items-center gap-0.5 sm:gap-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-1.5 sm:px-2 py-1 flex-shrink-0">
+        <span className="font-medium text-blue-100" style={{ fontSize: 'clamp(0.7rem, 1.8vw, 0.875rem)' }}>
           {userPoints.totalPoints.toLocaleString()} CP
         </span>
       </div>


### PR DESCRIPTION
Optimize RankingBar spacing and sizing for mobile to prevent points text overlapping with 'CP'.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b7e33b3-8645-4c6c-8019-19951e7b997e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b7e33b3-8645-4c6c-8019-19951e7b997e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>