### PR TITLE
Fix ranking bar translation overlap

### DIFF
--- a/src/translations/ar.ts
+++ b/src/translations/ar.ts
@@ -989,7 +989,7 @@ const ar = {
   'ranking.globalRank': 'الترتيب العالمي',
   'ranking.totalPoints': 'إجمالي النقاط',
   'ranking.currentLevel': 'المستوى الحالي',
-  'ranking.rankProgress': 'تقدم الترتيب',
+  'ranking.rankProgress': 'المستوى',
   'ranking.allTime': 'كل الأوقات',
   'ranking.seasonRank': 'ترتيب الموسم',
   'ranking.currentSeason': 'الموسم الحالي',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -856,7 +856,7 @@ const de = {
   'ranking.globalRank': 'Globaler Rang',
   'ranking.totalPoints': 'Gesamtpunkte',
   'ranking.currentLevel': 'Aktuelles Level',
-  'ranking.rankProgress': 'Rang-Fortschritt',
+  'ranking.rankProgress': 'Level',
   'ranking.allTime': 'Alle Zeiten',
   'ranking.seasonRank': 'Saison-Rang',
   'ranking.currentSeason': 'Aktuelle Saison',

--- a/src/translations/el.ts
+++ b/src/translations/el.ts
@@ -906,7 +906,7 @@ const el = {
   'ranking.globalRank': 'Παγκόσμια Κατάταξη',
   'ranking.totalPoints': 'Συνολικοί Πόντοι',
   'ranking.currentLevel': 'Τρέχον Επίπεδο',
-  'ranking.rankProgress': 'Πρόοδος Κατάταξης',
+  'ranking.rankProgress': 'Επίπεδο',
   'ranking.allTime': 'Όλων των Εποχών',
   'ranking.seasonRank': 'Κατάταξη Σεζόν',
   'ranking.currentSeason': 'Τρέχουσα Σεζόν',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -857,7 +857,7 @@ const en = {
   'ranking.globalRank': 'Global Rank',
   'ranking.totalPoints': 'Total Points',
   'ranking.currentLevel': 'Current Level',
-  'ranking.rankProgress': 'Rank Progress',
+  'ranking.rankProgress': 'Level',
   'ranking.allTime': 'All Time',
   'ranking.seasonRank': 'Season Rank',
   'ranking.currentSeason': 'Current Season',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -896,7 +896,7 @@ const es = {
   'ranking.globalRank': 'Rango Global',
   'ranking.totalPoints': 'Puntos Totales',
   'ranking.currentLevel': 'Nivel Actual',
-  'ranking.rankProgress': 'Progreso de Rango',
+  'ranking.rankProgress': 'Nivel',
   'ranking.allTime': 'Todos los Tiempos',
   'ranking.seasonRank': 'Rango de Temporada',
   'ranking.currentSeason': 'Temporada Actual',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -857,7 +857,7 @@ const fr = {
   'ranking.globalRank': 'Rang Mondial',
   'ranking.totalPoints': 'Points Totaux',
   'ranking.currentLevel': 'Niveau Actuel',
-  'ranking.rankProgress': 'Progression du Rang',
+  'ranking.rankProgress': 'Niveau',
   'ranking.allTime': 'Tous les Temps',
   'ranking.seasonRank': 'Rang Saisonnier',
   'ranking.currentSeason': 'Saison Actuelle',

--- a/src/translations/hi.ts
+++ b/src/translations/hi.ts
@@ -856,7 +856,7 @@ const hi = {
   'ranking.globalRank': 'वैश्विक रैंक',
   'ranking.totalPoints': 'कुल अंक',
   'ranking.currentLevel': 'वर्तमान स्तर',
-  'ranking.rankProgress': 'रैंक प्रगति',
+  'ranking.rankProgress': 'स्तर',
   'ranking.allTime': 'सभी समय',
   'ranking.seasonRank': 'सीज़न रैंक',
   'ranking.currentSeason': 'वर्तमान सीज़न',

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -859,7 +859,7 @@ const it = {
   'ranking.globalRank': 'Rango Globale',
   'ranking.totalPoints': 'Punti Totali',
   'ranking.currentLevel': 'Livello Attuale',
-  'ranking.rankProgress': 'Progresso Classifica',
+  'ranking.rankProgress': 'Livello',
   'ranking.allTime': 'Tutti i Tempi',
   'ranking.seasonRank': 'Rango Stagionale',
   'ranking.currentSeason': 'Stagione Attuale',

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -906,7 +906,7 @@ const ja = {
   'ranking.globalRank': 'グローバルランク',
   'ranking.totalPoints': '総ポイント',
   'ranking.currentLevel': '現在のレベル',
-  'ranking.rankProgress': 'ランク進行度',
+  'ranking.rankProgress': 'レベル',
   'ranking.allTime': '全期間',
   'ranking.seasonRank': 'シーズンランク',
   'ranking.currentSeason': '現在のシーズン',

--- a/src/translations/ko.ts
+++ b/src/translations/ko.ts
@@ -856,7 +856,7 @@ const ko = {
   'ranking.globalRank': '글로벌 순위',
   'ranking.totalPoints': '총 포인트',
   'ranking.currentLevel': '현재 레벨',
-  'ranking.rankProgress': '순위 진행도',
+  'ranking.rankProgress': '레벨',
   'ranking.allTime': '전체 기간',
   'ranking.seasonRank': '시즌 순위',
   'ranking.currentSeason': '현재 시즌',

--- a/src/translations/pt.ts
+++ b/src/translations/pt.ts
@@ -857,7 +857,7 @@ const pt = {
   'ranking.globalRank': 'Classificação Global',
   'ranking.totalPoints': 'Pontos Totais',
   'ranking.currentLevel': 'Nível Atual',
-  'ranking.rankProgress': 'Progresso da Classificação',
+  'ranking.rankProgress': 'Nível',
   'ranking.allTime': 'Todos os Tempos',
   'ranking.seasonRank': 'Classificação da Temporada',
   'ranking.currentSeason': 'Temporada Atual',

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -840,7 +840,7 @@ const ru = {
   'ranking.globalRank': 'Глобальный Рейтинг',
   'ranking.totalPoints': 'Общие Очки',
   'ranking.currentLevel': 'Текущий Уровень',
-  'ranking.rankProgress': 'Прогресс Рейтинга',
+  'ranking.rankProgress': 'Уровень',
   'ranking.allTime': 'За Все Время',
   'ranking.seasonRank': 'Рейтинг Сезона',
   'ranking.currentSeason': 'Текущий Сезон',

--- a/src/translations/tr.ts
+++ b/src/translations/tr.ts
@@ -857,7 +857,7 @@ const tr = {
   'ranking.globalRank': 'Küresel Sıralama',
   'ranking.totalPoints': 'Toplam Puan',
   'ranking.currentLevel': 'Mevcut Seviye',
-  'ranking.rankProgress': 'Sıralama İlerlemesi',
+  'ranking.rankProgress': 'Seviye',
   'ranking.allTime': 'Tüm Zamanlar',
   'ranking.seasonRank': 'Sezon Sıralaması',
   'ranking.currentSeason': 'Mevcut Sezon',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -906,7 +906,7 @@ const zh = {
   'ranking.globalRank': '全球排名',
   'ranking.totalPoints': '总积分',
   'ranking.currentLevel': '当前等级',
-  'ranking.rankProgress': '排名进度',
+  'ranking.rankProgress': '等级',
   'ranking.allTime': '全时期',
   'ranking.seasonRank': '赛季排名',
   'ranking.currentSeason': '当前赛季',


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replaced "Rank Progress" text with "Level" in the ranking bar to resolve UI overlapping issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous "Rank Progress" translations varied significantly in length (e.g., "Progresso da Classificação" in Portuguese was 25 characters), causing text overlaps in the compact ranking bar. Changing it to "Level" (which is 2-7 characters across all languages) ensures a consistent and clean layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-c317ac22-ab1a-4006-8de5-a851f7a17061">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c317ac22-ab1a-4006-8de5-a851f7a17061">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>