### PR TITLE
Ranking bar width adjustment for compactness

### DIFF
--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -17,42 +17,42 @@ const RankingBar: React.FC = () => {
   const progressPercentage = Math.min(((user.xp || 0) % 1000) / 10, 100)
 
   return (
-    <div className="fixed z-40 flex items-center gap-1 sm:gap-2 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
+    <div className="fixed z-40 flex items-center gap-1 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
          style={{
            top: 'clamp(0.5rem, 2vw, 1rem)',
            left: '50%',
            transform: 'translateX(-50%)',
-           padding: 'clamp(0.25rem, 1vw, 0.5rem)',
-           minWidth: 'clamp(180px, 30vw, 280px)',
-           maxWidth: 'clamp(280px, 40vw, 350px)'
+           padding: 'clamp(0.2rem, 0.8vw, 0.3rem)',
+           minWidth: 'clamp(90px, 15vw, 140px)',
+           maxWidth: 'clamp(140px, 20vw, 175px)'
          }}>
       
       {/* Rank Badge */}
-      <div className="flex items-center gap-1 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-1.5 sm:px-2 py-1 flex-shrink-0">
-        <Trophy className="text-yellow-400" style={{ width: 'clamp(10px, 2.5vw, 16px)', height: 'clamp(10px, 2.5vw, 16px)' }} />
-        <span className="font-medium text-yellow-100" style={{ fontSize: 'clamp(0.7rem, 1.8vw, 0.875rem)' }}>
+      <div className="flex items-center gap-0.5 bg-gradient-to-r from-yellow-500/20 to-amber-500/20 border border-yellow-400/30 rounded px-1 py-0.5 flex-shrink-0">
+        <Trophy className="text-yellow-400" style={{ width: 'clamp(8px, 2vw, 12px)', height: 'clamp(8px, 2vw, 12px)' }} />
+        <span className="font-medium text-yellow-100" style={{ fontSize: 'clamp(0.6rem, 1.5vw, 0.75rem)' }}>
           #{currentRank || 'N/A'}
         </span>
       </div>
 
       {/* Progress Bar Container */}
-      <div className="flex-1 min-w-0 mx-0.5 sm:mx-1">
+      <div className="flex-1 min-w-0 mx-0.5">
         {/* Level label centered at top */}
         <div className="text-center mb-0.5">
-          <span className="text-slate-300" style={{ fontSize: 'clamp(0.6rem, 1.5vw, 0.75rem)' }}>
+          <span className="text-slate-300" style={{ fontSize: 'clamp(0.55rem, 1.3vw, 0.65rem)' }}>
             {t('ranking.rankProgress')}
           </span>
         </div>
         
         {/* Score centered below level */}
         <div className="text-center mb-0.5">
-          <span className="text-slate-400" style={{ fontSize: 'clamp(0.6rem, 1.5vw, 0.75rem)' }}>
-            {Math.min(((user.xp || 0) % 1000), 1000)}/1000 XP
+          <span className="text-slate-400" style={{ fontSize: 'clamp(0.5rem, 1.2vw, 0.6rem)' }}>
+            {Math.min(((user.xp || 0) % 1000), 1000)}/1000
           </span>
         </div>
         
         {/* Progress Bar */}
-        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(3px, 1vw, 6px)' }}>
+        <div className="w-full bg-slate-600 rounded-full" style={{ height: 'clamp(2px, 0.8vw, 4px)' }}>
           <div 
             className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-full transition-all duration-300"
             style={{ 
@@ -64,9 +64,9 @@ const RankingBar: React.FC = () => {
       </div>
 
       {/* Points Display */}
-      <div className="flex items-center gap-0.5 sm:gap-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-1.5 sm:px-2 py-1 flex-shrink-0">
-        <span className="font-medium text-blue-100" style={{ fontSize: 'clamp(0.7rem, 1.8vw, 0.875rem)' }}>
-          {userPoints.totalPoints.toLocaleString()} CP
+      <div className="flex items-center gap-0.5 bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 rounded px-1 py-0.5 flex-shrink-0">
+        <span className="font-medium text-blue-100" style={{ fontSize: 'clamp(0.6rem, 1.5vw, 0.75rem)' }}>
+          {userPoints.totalPoints > 999 ? `${Math.floor(userPoints.totalPoints / 1000)}k` : userPoints.totalPoints}
         </span>
       </div>
     </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make the ranking bar vertically more compact and half as wide to reduce its visual footprint.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ce89717-4630-47fa-961b-4592cca2252a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ce89717-4630-47fa-961b-4592cca2252a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>