### PR TITLE
Resize ranking bar vertically

### DIFF
--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -17,14 +17,15 @@ const RankingBar: React.FC = () => {
   const progressPercentage = Math.min(((user.xp || 0) % 1000) / 10, 100)
 
   return (
-    <div className="fixed z-40 flex items-center gap-1 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
+    <div className="fixed z-40 flex items-center gap-2 bg-slate-800/90 backdrop-blur-sm rounded-lg border border-slate-600 shadow-lg"
          style={{
            top: 'clamp(0.5rem, 2vw, 1rem)',
            left: '50%',
-           transform: 'translateX(-50%)',
-           padding: 'clamp(0.2rem, 0.8vw, 0.3rem)',
-           minWidth: 'clamp(90px, 15vw, 140px)',
-           maxWidth: 'clamp(140px, 20vw, 175px)'
+           transform: 'translateX(-50%) scaleY(0.5)',
+           transformOrigin: 'top center',
+           padding: 'clamp(0.4rem, 1.6vw, 0.6rem) clamp(0.6rem, 2.4vw, 0.9rem)',
+           minWidth: 'clamp(180px, 30vw, 280px)',
+           maxWidth: 'clamp(280px, 40vw, 350px)'
          }}>
       
       {/* Rank Badge */}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make the ranking bar half as tall vertically and restore its original horizontal width, as per user request.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous change incorrectly halved the ranking bar's horizontal size instead of its vertical size. This PR corrects that by restoring the original horizontal dimensions and applying a `scaleY(0.5)` transform for vertical reduction.

---
<a href="https://cursor.com/background-agent?bcId=bc-96e13e58-d9a3-4680-b261-4f96cceb595e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96e13e58-d9a3-4680-b261-4f96cceb595e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>