### PR TITLE
Adjust ranking bar spacing for readability

### DIFF
--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -39,14 +39,14 @@ const RankingBar: React.FC = () => {
       {/* Progress Bar Container */}
       <div className="flex-1 min-w-0 mx-1 h-full flex flex-col justify-center">
         {/* Level label */}
-        <div className="text-center mb-1">
+        <div className="text-center">
           <span className="text-slate-200 font-medium" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
             {t('ranking.rankProgress')}
           </span>
         </div>
         
         {/* Score */}
-        <div className="text-center mb-1.5">
+        <div className="text-center">
           <span className="text-slate-300 font-semibold" style={{ fontSize: 'clamp(0.7rem, 1.7vw, 0.8rem)' }}>
             {Math.min(((user.xp || 0) % 1000), 1000)}/1000
           </span>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove `mb-1` and `mb-1.5` classes from RankingBar elements to eliminate spacing between Level, points, and the progress bar, keeping content within the card.

---
<a href="https://cursor.com/background-agent?bcId=bc-abc395d5-6172-400e-bb30-0777f4979fe4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-abc395d5-6172-400e-bb30-0777f4979fe4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>