### PR TITLE
Replace Ranking Fortschritt with RankPR in all languages

### DIFF
--- a/src/translations/ar.ts
+++ b/src/translations/ar.ts
@@ -989,7 +989,7 @@ const ar = {
   'ranking.globalRank': 'الترتيب العالمي',
   'ranking.totalPoints': 'إجمالي النقاط',
   'ranking.currentLevel': 'المستوى الحالي',
-  'ranking.rankProgress': 'المستوى',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'كل الأوقات',
   'ranking.seasonRank': 'ترتيب الموسم',
   'ranking.currentSeason': 'الموسم الحالي',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -856,7 +856,7 @@ const de = {
   'ranking.globalRank': 'Globaler Rang',
   'ranking.totalPoints': 'Gesamtpunkte',
   'ranking.currentLevel': 'Aktuelles Level',
-  'ranking.rankProgress': 'Level',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Alle Zeiten',
   'ranking.seasonRank': 'Saison-Rang',
   'ranking.currentSeason': 'Aktuelle Saison',

--- a/src/translations/el.ts
+++ b/src/translations/el.ts
@@ -906,7 +906,7 @@ const el = {
   'ranking.globalRank': 'Παγκόσμια Κατάταξη',
   'ranking.totalPoints': 'Συνολικοί Πόντοι',
   'ranking.currentLevel': 'Τρέχον Επίπεδο',
-  'ranking.rankProgress': 'Επίπεδο',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Όλων των Εποχών',
   'ranking.seasonRank': 'Κατάταξη Σεζόν',
   'ranking.currentSeason': 'Τρέχουσα Σεζόν',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -857,7 +857,7 @@ const en = {
   'ranking.globalRank': 'Global Rank',
   'ranking.totalPoints': 'Total Points',
   'ranking.currentLevel': 'Current Level',
-  'ranking.rankProgress': 'Level',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'All Time',
   'ranking.seasonRank': 'Season Rank',
   'ranking.currentSeason': 'Current Season',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -896,7 +896,7 @@ const es = {
   'ranking.globalRank': 'Rango Global',
   'ranking.totalPoints': 'Puntos Totales',
   'ranking.currentLevel': 'Nivel Actual',
-  'ranking.rankProgress': 'Nivel',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Todos los Tiempos',
   'ranking.seasonRank': 'Rango de Temporada',
   'ranking.currentSeason': 'Temporada Actual',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -857,7 +857,7 @@ const fr = {
   'ranking.globalRank': 'Rang Mondial',
   'ranking.totalPoints': 'Points Totaux',
   'ranking.currentLevel': 'Niveau Actuel',
-  'ranking.rankProgress': 'Niveau',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Tous les Temps',
   'ranking.seasonRank': 'Rang Saisonnier',
   'ranking.currentSeason': 'Saison Actuelle',

--- a/src/translations/hi.ts
+++ b/src/translations/hi.ts
@@ -856,7 +856,7 @@ const hi = {
   'ranking.globalRank': 'वैश्विक रैंक',
   'ranking.totalPoints': 'कुल अंक',
   'ranking.currentLevel': 'वर्तमान स्तर',
-  'ranking.rankProgress': 'स्तर',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'सभी समय',
   'ranking.seasonRank': 'सीज़न रैंक',
   'ranking.currentSeason': 'वर्तमान सीज़न',

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -859,7 +859,7 @@ const it = {
   'ranking.globalRank': 'Rango Globale',
   'ranking.totalPoints': 'Punti Totali',
   'ranking.currentLevel': 'Livello Attuale',
-  'ranking.rankProgress': 'Livello',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Tutti i Tempi',
   'ranking.seasonRank': 'Rango Stagionale',
   'ranking.currentSeason': 'Stagione Attuale',

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -906,7 +906,7 @@ const ja = {
   'ranking.globalRank': 'グローバルランク',
   'ranking.totalPoints': '総ポイント',
   'ranking.currentLevel': '現在のレベル',
-  'ranking.rankProgress': 'レベル',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': '全期間',
   'ranking.seasonRank': 'シーズンランク',
   'ranking.currentSeason': '現在のシーズン',

--- a/src/translations/ko.ts
+++ b/src/translations/ko.ts
@@ -856,7 +856,7 @@ const ko = {
   'ranking.globalRank': '글로벌 순위',
   'ranking.totalPoints': '총 포인트',
   'ranking.currentLevel': '현재 레벨',
-  'ranking.rankProgress': '레벨',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': '전체 기간',
   'ranking.seasonRank': '시즌 순위',
   'ranking.currentSeason': '현재 시즌',

--- a/src/translations/pt.ts
+++ b/src/translations/pt.ts
@@ -857,7 +857,7 @@ const pt = {
   'ranking.globalRank': 'Classificação Global',
   'ranking.totalPoints': 'Pontos Totais',
   'ranking.currentLevel': 'Nível Atual',
-  'ranking.rankProgress': 'Nível',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Todos os Tempos',
   'ranking.seasonRank': 'Classificação da Temporada',
   'ranking.currentSeason': 'Temporada Atual',

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -840,7 +840,7 @@ const ru = {
   'ranking.globalRank': 'Глобальный Рейтинг',
   'ranking.totalPoints': 'Общие Очки',
   'ranking.currentLevel': 'Текущий Уровень',
-  'ranking.rankProgress': 'Уровень',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'За Все Время',
   'ranking.seasonRank': 'Рейтинг Сезона',
   'ranking.currentSeason': 'Текущий Сезон',

--- a/src/translations/tr.ts
+++ b/src/translations/tr.ts
@@ -857,7 +857,7 @@ const tr = {
   'ranking.globalRank': 'Küresel Sıralama',
   'ranking.totalPoints': 'Toplam Puan',
   'ranking.currentLevel': 'Mevcut Seviye',
-  'ranking.rankProgress': 'Seviye',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': 'Tüm Zamanlar',
   'ranking.seasonRank': 'Sezon Sıralaması',
   'ranking.currentSeason': 'Mevcut Sezon',

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -906,7 +906,7 @@ const zh = {
   'ranking.globalRank': '全球排名',
   'ranking.totalPoints': '总积分',
   'ranking.currentLevel': '当前等级',
-  'ranking.rankProgress': '等级',
+  'ranking.rankProgress': 'RankPR',
   'ranking.allTime': '全时期',
   'ranking.seasonRank': '赛季排名',
   'ranking.currentSeason': '当前赛季',


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replace "Ranking Fortschritt" with "RankPR" across all language translation files as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f6e23f1-d21a-4ba8-ba54-b73b231c6bf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f6e23f1-d21a-4ba8-ba54-b73b231c6bf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>