### PR TITLE
Reduce ranking card size in build 274 horizontal

### DIFF
--- a/src/components/RankingBar.tsx
+++ b/src/components/RankingBar.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useUser } from '../contexts/UserContext'
 import { usePoints } from '../contexts/PointsContext'
 import { useLanguage } from '../contexts/LanguageContext'
+import { Trophy } from 'lucide-react'
 
 const RankingBar: React.FC = () => {
   const { user, isAuthenticated } = useUser()
@@ -15,43 +16,47 @@ const RankingBar: React.FC = () => {
   const currentRank = getUserPosition(user.id, { type: 'global', timeframe: 'allTime' })
   const currentXP = (user.xp || 0) % 1000
   const maxXP = 1000
+  const progressPercentage = Math.min((currentXP / maxXP) * 100, 100)
 
   return (
-    <div className="fixed z-40 w-full max-w-[400px] mx-auto"
+    <div className="fixed z-40 w-full max-w-[320px] mx-auto"
          style={{
            top: 'clamp(0.5rem, 2vw, 1rem)',
            left: '50%',
            transform: 'translateX(-50%)',
          }}>
       
-      <div className="w-full max-w-[360px] mx-auto px-3 py-3 bg-[#0e0e1a]/90 backdrop-blur-sm rounded-md shadow text-white text-xs border border-slate-600">
+      <div className="flex items-center justify-between w-full px-2 py-1.5 bg-[#0e0e1a] rounded-md shadow-md text-white text-xs">
 
-        {/* Kopfzeile mit #1 – LEVEL – CP */}
-        <div className="flex items-center justify-between w-full mb-1">
-          <div className="bg-yellow-400 text-black font-bold px-2 py-1 rounded-md text-xs shadow">
-            🏆 #{currentRank || '1'}
-          </div>
-          <span className="uppercase text-[11px] font-semibold tracking-wide text-slate-300 text-center">
+        {/* Rank Display - Yellow Badge */}
+        <div className="flex items-center gap-1 px-1.5 py-0.5 bg-yellow-400 text-black font-bold rounded text-xs shadow flex-shrink-0">
+          <Trophy className="w-3 h-3" />
+          <span className="leading-none">#{currentRank || '1'}</span>
+        </div>
+
+        {/* XP / Level Center Section */}
+        <div className="flex flex-col items-center justify-center gap-[1px] px-2 min-w-[100px] flex-1">
+          <span className="uppercase tracking-wider text-[10px] font-semibold text-slate-300 leading-none">
             {t('profile.level')}
           </span>
-          <div className="bg-purple-600 text-white font-semibold px-2 py-1 rounded-md text-xs shadow">
+          <span className="text-xs font-medium leading-none text-white">
+            {currentXP} / {maxXP}
+          </span>
+          <div className="relative w-full h-1 mt-[1px] bg-slate-700 rounded-full overflow-hidden">
+            <div
+              className="absolute top-0 left-0 h-full bg-green-400 transition-all duration-300 ease-out rounded-full"
+              style={{ width: `${progressPercentage}%` }}
+            />
+          </div>
+        </div>
+
+        {/* CP Value - Purple Badge */}
+        <div className="flex items-center justify-center px-1.5 py-0.5 bg-purple-600 text-white font-semibold rounded shadow text-xs flex-shrink-0">
+          <span className="leading-none">
             {userPoints.totalPoints > 999 
               ? `${Math.floor(userPoints.totalPoints / 1000)}k` 
               : userPoints.totalPoints} CP
-          </div>
-        </div>
-
-        {/* XP-Wert */}
-        <div className="text-center mb-1 text-sm font-medium text-slate-300">
-          {currentXP} / {maxXP}
-        </div>
-
-        {/* Fortschrittsleiste */}
-        <div className="relative w-full h-1.5 bg-slate-700 rounded-full overflow-hidden">
-          <div
-            className="absolute top-0 left-0 h-full bg-green-400 transition-all duration-300 ease-out rounded-full"
-            style={{ width: `${(currentXP / maxXP) * 100}%` }}
-          ></div>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Revert the RankingBar component to its compact horizontal layout (from PR #274) and reduce its overall size to make it less prominent.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b12b234-4755-41c7-9861-372a26bd31f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b12b234-4755-41c7-9861-372a26bd31f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>