### PR TITLE
Vereinheitliche meta leiste in allen karten

### DIFF
--- a/src/components/InteractionComponents.tsx
+++ b/src/components/InteractionComponents.tsx
@@ -70,17 +70,13 @@ export const LikeButton: React.FC<LikeButtonProps> = ({
     <button
       onClick={handleLike}
       disabled={!user || isLiking}
-      className={`flex items-center ${!compact ? 'gap-1.5 sm:gap-2' : ''} transition-all duration-200 ${
-        isLiked 
-          ? 'text-white hover:text-gray-200' 
-          : 'text-white hover:text-gray-200'
-      } ${!user ? 'opacity-50 cursor-not-allowed' : 'hover:scale-105'} ${className}`}
+      className={`flex items-center ${!compact ? 'gap-1.5 sm:gap-2' : ''} transition-all duration-200 text-white hover:text-white ${!user ? 'opacity-50 cursor-not-allowed' : 'hover:scale-105'} ${className}`}
       title={user ? (isLiked ? t('interaction.unlike') : t('interaction.like')) : t('interaction.loginToLike')}
     >
-      <Heart className={`${compact ? 'w-4 h-4' : 'w-4 h-4'} flex-shrink-0 ${isLiked ? 'fill-white text-white scale-110' : ''} transition-all`} />
+      <Heart className={`${compact ? 'w-4 h-4' : 'w-4 h-4'} flex-shrink-0 ${isLiked ? 'fill-white text-white scale-110' : 'text-white'} transition-all`} />
       {!compact && (
         <span className="text-xs sm:text-sm font-medium min-w-[1ch] text-white">
-          {interactionData.likes > 0 ? interactionData.likes : ''}
+          {interactionData.likes}
         </span>
       )}
     </button>
@@ -109,10 +105,10 @@ export const ViewCounter: React.FC<ViewCounterProps> = ({
   // Always show the view counter, even without authentication
   return (
     <div className={`flex items-center ${!compact ? 'gap-1.5 sm:gap-2' : ''} text-white ${className}`}>
-      <Eye className={`${compact ? 'w-4 h-4' : 'w-4 h-4'} flex-shrink-0 transition-all`} />
+      <Eye className={`${compact ? 'w-4 h-4' : 'w-4 h-4'} flex-shrink-0 text-white transition-all`} />
       {!compact && (
         <span className="text-xs sm:text-sm min-w-[1ch] text-white">
-          {interactionData.views > 0 ? interactionData.views : '0'}
+          {interactionData.views}
         </span>
       )}
     </div>
@@ -176,9 +172,9 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
       {/* Comment Toggle Button */}
       <button
         onClick={() => setShowComments(!showComments)}
-        className="flex items-center gap-2 text-white hover:text-gray-200 transition-colors"
+        className="flex items-center gap-2 text-white hover:text-white transition-colors"
       >
-        <MessageCircle className="w-4 h-4" />
+        <MessageCircle className="w-4 h-4 text-white" />
         <span className="text-xs sm:text-sm font-medium text-white">
           {interactionData.comments.length > 0 
             ? `${interactionData.comments.length} ${t('interaction.comments')}`
@@ -366,7 +362,7 @@ const CompactInteractionBar: React.FC<CompactInteractionBarProps> = ({
           <CompactHeartIcon filled={isLiked} />
         </button>
         <span className="text-white font-medium min-w-[1ch]" style={{ fontSize: '11px' }}>
-          {interactionData.likes > 0 ? interactionData.likes : '0'}
+          {interactionData.likes}
         </span>
       </div>
       
@@ -374,7 +370,7 @@ const CompactInteractionBar: React.FC<CompactInteractionBarProps> = ({
       <div className="flex items-center" style={{ gap: '4px' }} title={t('interaction.viewCount')} aria-label={t('interaction.viewCount')}>
         <CompactEyeIcon />
         <span className="text-white font-medium min-w-[1ch]" style={{ fontSize: '11px' }}>
-          {interactionData.views > 0 ? interactionData.views : '0'}
+          {interactionData.views}
         </span>
       </div>
       
@@ -391,7 +387,7 @@ const CompactInteractionBar: React.FC<CompactInteractionBarProps> = ({
             <CompactCommentIcon />
           </button>
           <span className="text-white font-medium min-w-[1ch]" style={{ fontSize: '11px' }}>
-            {interactionData.comments.length > 0 ? interactionData.comments.length : '0'}
+            {interactionData.comments.length}
           </span>
         </div>
       )}
@@ -452,7 +448,7 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
   return (
     <div className={`space-y-2 ${className}`}>
       {/* Action Buttons */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-start">
         <div className="flex items-center gap-3 sm:gap-4">
           <LikeButton 
             contentType={contentType} 
@@ -465,12 +461,6 @@ export const InteractionBar: React.FC<InteractionBarProps> = ({
             compact={compact}
           />
         </div>
-        
-        {!compact && interactionData.likes > 0 && (
-          <div className="text-xs text-slate-400">
-            {interactionData.likes} {interactionData.likes === 1 ? 'like' : 'likes'}
-          </div>
-        )}
       </div>
 
       {/* Comments Section */}

--- a/src/components/UserMediaHistory.tsx
+++ b/src/components/UserMediaHistory.tsx
@@ -166,17 +166,17 @@ const UserMediaHistory: React.FC<UserMediaHistoryProps> = ({ className = '' }) =
           )}
 
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4 text-xs text-slate-400">
+            <div className="flex items-center gap-4 text-xs text-white">
               <span className="flex items-center gap-1">
-                <Calendar className="w-3 h-3" />
+                <Calendar className="w-3 h-3 text-white" />
                 {formatDate(new Date(media.uploadDate))}
               </span>
               <span className="flex items-center gap-1">
-                <Eye className="w-3 h-3" />
+                <Eye className="w-3 h-3 text-white" />
                 {media.views}
               </span>
               <span className="flex items-center gap-1">
-                <Heart className="w-3 h-3" />
+                <Heart className="w-3 h-3 text-white" />
                 {media.likes}
               </span>
             </div>

--- a/src/pages/FanArtPage.tsx
+++ b/src/pages/FanArtPage.tsx
@@ -811,31 +811,31 @@ const FanArtPage: React.FC = () => {
                           !isAuthenticated 
                             ? 'cursor-not-allowed opacity-50' 
                             : userLikes.has(item.id)
-                            ? 'text-pink-400 hover:text-pink-300'
-                            : 'text-slate-400 hover:text-pink-400'
+                            ? 'text-white hover:text-gray-200'
+                            : 'text-white hover:text-gray-200'
                         }`}
                         disabled={!isAuthenticated}
                       >
                         <Heart 
                           className={`w-4 h-4 transition-all ${
                             userLikes.has(item.id) 
-                              ? 'fill-pink-400 text-pink-400 scale-110' 
-                              : 'text-slate-400'
+                              ? 'fill-white text-white scale-110' 
+                              : 'text-white'
                           }`} 
                         />
-                        <span>{item.likes}</span>
+                        <span className="text-white">{item.likes}</span>
                       </button>
                     </div>
                     <div className="flex items-center gap-1">
-                      <Eye className="w-4 h-4" />
-                      <span>{item.views}</span>
+                      <Eye className="w-4 h-4 text-white" />
+                      <span className="text-white">{item.views}</span>
                     </div>
                     <button
                       onClick={() => setShowComments(showComments === item.id ? null : item.id)}
-                      className="flex items-center gap-1 text-slate-400 hover:text-blue-400 transition-colors"
+                      className="flex items-center gap-1 text-white hover:text-gray-200 transition-colors"
                     >
-                      <MessageSquare className="w-4 h-4" />
-                      <span>{item.comments}</span>
+                      <MessageSquare className="w-4 h-4 text-white" />
+                      <span className="text-white">{item.comments}</span>
                     </button>
                   </div>
                   <span className="text-xs">
@@ -956,31 +956,31 @@ const FanArtPage: React.FC = () => {
                             !isAuthenticated 
                               ? 'cursor-not-allowed opacity-50' 
                               : userLikes.has(item.id)
-                              ? 'text-pink-400 hover:text-pink-300'
-                              : 'text-slate-400 hover:text-pink-400'
+                              ? 'text-white hover:text-gray-200'
+                              : 'text-white hover:text-gray-200'
                           }`}
                           disabled={!isAuthenticated}
                         >
                           <Heart 
                             className={`w-4 h-4 transition-all ${
                               userLikes.has(item.id) 
-                                ? 'fill-pink-400 text-pink-400 scale-110' 
-                                : 'text-slate-400'
+                                ? 'fill-white text-white scale-110' 
+                                : 'text-white'
                             }`} 
                           />
-                          <span>{item.likes}</span>
+                          <span className="text-white">{item.likes}</span>
                         </button>
                       </div>
                       <div className="flex items-center gap-1">
-                        <Eye className="w-4 h-4" />
-                        <span>{item.views}</span>
+                        <Eye className="w-4 h-4 text-white" />
+                        <span className="text-white">{item.views}</span>
                       </div>
                       <button
                         onClick={() => setShowComments(showComments === item.id ? null : item.id)}
-                        className="flex items-center gap-1 text-slate-400 hover:text-blue-400 transition-colors"
+                        className="flex items-center gap-1 text-white hover:text-gray-200 transition-colors"
                       >
-                        <MessageSquare className="w-4 h-4" />
-                        <span>{item.comments}</span>
+                        <MessageSquare className="w-4 h-4 text-white" />
+                        <span className="text-white">{item.comments}</span>
                       </button>
                     </div>
                     <span className="text-xs">

--- a/src/pages/ForumCategoryPage.tsx
+++ b/src/pages/ForumCategoryPage.tsx
@@ -231,12 +231,12 @@ const ForumCategoryPage: React.FC = () => {
 
                 {/* Thread Stats */}
                 <div className="flex items-center gap-6 text-sm">
-                  <div className="flex items-center gap-1 text-slate-400">
-                    <MessageSquare className="w-4 h-4" />
+                  <div className="flex items-center gap-1 text-white">
+                    <MessageSquare className="w-4 h-4 text-white" />
                     <span>{thread.postCount}</span>
                   </div>
-                  <div className="flex items-center gap-1 text-slate-400">
-                    <Eye className="w-4 h-4" />
+                  <div className="flex items-center gap-1 text-white">
+                    <Eye className="w-4 h-4 text-white" />
                     <span>{thread.views}</span>
                   </div>
                 </div>

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -168,21 +168,21 @@ const ForumThreadPage: React.FC = () => {
                 {selectedThread.title}
               </h1>
             </div>
-            <div className="flex items-center gap-4 text-sm text-slate-400">
+            <div className="flex items-center gap-4 text-sm text-white">
               <div className="flex items-center gap-1">
-                <User className="w-4 h-4" />
+                <User className="w-4 h-4 text-white" />
                 <span>{t('forum.createdBy')} {selectedThread.authorName}</span>
               </div>
               <div className="flex items-center gap-1">
-                <Clock className="w-4 h-4" />
+                <Clock className="w-4 h-4 text-white" />
                 <span>{formatDate(selectedThread.createdAt)}</span>
               </div>
               <div className="flex items-center gap-1">
-                <Eye className="w-4 h-4" />
+                <Eye className="w-4 h-4 text-white" />
                 <span>{selectedThread.views} Aufrufe</span>
               </div>
               <div className="flex items-center gap-1">
-                <MessageSquare className="w-4 h-4" />
+                <MessageSquare className="w-4 h-4 text-white" />
                 <span>{selectedThread.postCount} Beiträge</span>
               </div>
             </div>

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -537,18 +537,18 @@ const MarketplacePage: React.FC = () => {
                 </div>
               </div>
               
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between text-responsive-xs text-slate-400 gap-2">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between text-responsive-xs text-white gap-2">
                 <div className="flex items-center gap-3 flex-wrap">
                   <div className="flex items-center gap-1">
-                    <Eye size={12} />
+                    <Eye size={12} className="text-white" />
                     <span>{offer.views}</span>
                   </div>
                   <div className="flex items-center gap-1">
-                    <Heart size={12} />
+                    <Heart size={12} className="text-white" />
                     <span>{offer.likes}</span>
                   </div>
                   <div className="flex items-center gap-1">
-                    <MessageCircle size={12} />
+                    <MessageCircle size={12} className="text-white" />
                     <span>{offer.comments}</span>
                   </div>
                 </div>

--- a/src/pages/SpeedrunMediaPage.tsx
+++ b/src/pages/SpeedrunMediaPage.tsx
@@ -361,13 +361,13 @@ const SpeedrunMediaPage: React.FC = () => {
         </div>
         
         <div className="flex items-center justify-between mt-3">
-          <div className="flex items-center gap-4 text-xs text-slate-400">
+          <div className="flex items-center gap-4 text-xs text-white">
             <span className="flex items-center gap-1">
-              <Eye className="w-3 h-3" />
+              <Eye className="w-3 h-3 text-white" />
               {media.views}
             </span>
             <span className="flex items-center gap-1">
-              <Heart className="w-3 h-3" />
+              <Heart className="w-3 h-3 text-white" />
               {media.likes}
             </span>
           </div>
@@ -958,12 +958,12 @@ const SpeedrunMediaPage: React.FC = () => {
 
                       <div className="flex items-center gap-4">
                         <div className="flex items-center gap-1">
-                          <Eye className="w-4 h-4 text-slate-400" />
-                          <span className="text-slate-300">{selectedMedia.views}</span>
+                          <Eye className="w-4 h-4 text-white" />
+                          <span className="text-white">{selectedMedia.views}</span>
                         </div>
                         <div className="flex items-center gap-1">
-                          <Heart className="w-4 h-4 text-slate-400" />
-                          <span className="text-slate-300">{selectedMedia.likes}</span>
+                          <Heart className="w-4 h-4 text-white" />
+                          <span className="text-white">{selectedMedia.likes}</span>
                         </div>
                         {selectedMedia.verified && (
                           <div className="flex items-center gap-1">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Unify meta bar (likes, views, comments) styling to be consistently white and left-aligned across all card types.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab2da552-293b-4138-a16b-14aed840c9c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab2da552-293b-4138-a16b-14aed840c9c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>