### PR TITLE
Forum threads and comments mobile display fix

### DIFF
--- a/src/components/SingleForumCard.tsx
+++ b/src/components/SingleForumCard.tsx
@@ -106,33 +106,35 @@ const SingleForumCard: React.FC<SingleForumCardProps> = ({ forumThreads, classNa
       </div>
       
       <div className="swipeable-card-content">
-        <div className="p-3 h-full flex flex-col">
-          <div className="flex-1">
-            <h4 className="text-sm sm:text-base font-semibold text-slate-100 mb-2 leading-tight">
+        <div className="p-2 sm:p-3 h-full flex flex-col">
+          <div className="flex-1 min-w-0">
+            <h4 className="text-sm sm:text-base font-semibold text-slate-100 mb-2 leading-tight break-words">
               {thread.title}
             </h4>
-            <div className="text-xs text-slate-300 mb-2">
-              <span className="text-blue-400">{thread.author}</span> • {thread.category}
+            <div className="text-xs text-slate-300 mb-2 break-words">
+              <span className="text-blue-400 break-words">{thread.author}</span> • <span className="break-words">{thread.category}</span>
             </div>
             {/* Show last post content if available */}
             {thread.lastPostContent && (
-              <div className="text-xs text-slate-400 mb-2 line-clamp-2">
-                <span className="text-cyan-400">Letzte Antwort von {thread.lastPostAuthor || 'Unbekannt'}:</span>
+              <div className="text-xs text-slate-400 mb-2 line-clamp-2 break-words">
+                <span className="text-cyan-400 break-words">Letzte Antwort von {thread.lastPostAuthor || 'Unbekannt'}:</span>
                 <br />
-                {thread.lastPostContent.length > 80 
-                  ? `${thread.lastPostContent.substring(0, 80)}...` 
-                  : thread.lastPostContent
-                }
+                <span className="break-words">
+                  {thread.lastPostContent.length > 60 
+                    ? `${thread.lastPostContent.substring(0, 60)}...` 
+                    : thread.lastPostContent
+                  }
+                </span>
               </div>
             )}
           </div>
-          <div className="flex items-center justify-between text-xs text-slate-400 mt-auto">
-            <span>{thread.replies} Antworten</span>
-            <span>{formatTime(thread.lastActivity)}</span>
+          <div className="flex items-center justify-between text-xs text-slate-400 mt-auto gap-2">
+            <span className="whitespace-nowrap">{thread.replies} Antworten</span>
+            <span className="whitespace-nowrap">{formatTime(thread.lastActivity)}</span>
           </div>
           
           {/* Interaction Bar */}
-          <div className="mt-3 pt-3 border-t border-slate-600/30">
+          <div className="mt-2 sm:mt-3 pt-2 sm:pt-3 border-t border-slate-600/30">
             <InteractionBar 
               contentType="forum"
               contentId={thread.id}

--- a/src/index.css
+++ b/src/index.css
@@ -679,6 +679,34 @@ code {
   }
 }
 
+/* Forum Mobile Optimizations */
+@media (max-width: 768px) {
+  .simple-tile {
+    padding: clamp(0.75rem, 3vw, 1rem);
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+  
+  .simple-tile * {
+    max-width: 100%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+  
+  .simple-tile pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    overflow-x: auto;
+  }
+  
+  .simple-tile img {
+    max-width: 100% !important;
+    height: auto !important;
+    object-fit: contain;
+  }
+}
+
 /* Prevent border overlapping in horizontal mode */
 @media (orientation: landscape) and (max-height: 500px) {
   .n64-tile, .simple-tile {

--- a/src/pages/ForumCategoryPage.tsx
+++ b/src/pages/ForumCategoryPage.tsx
@@ -119,29 +119,29 @@ const ForumCategoryPage: React.FC = () => {
       <div className="mb-6">
         <Link 
           to="/forum" 
-          className="inline-flex items-center gap-2 text-slate-400 hover:text-slate-200 transition-colors"
+          className="inline-flex items-center gap-2 text-slate-400 hover:text-slate-200 transition-colors py-2 px-1 -mx-1 rounded-lg hover:bg-slate-700/50 min-h-[44px]"
         >
-          <ArrowLeft className="w-4 h-4" />
-          {t('common.back')} zum Forum
+          <ArrowLeft className="w-4 h-4 flex-shrink-0" />
+          <span className="text-sm sm:text-base">{t('common.back')} zum Forum</span>
         </Link>
       </div>
 
       {/* Category Header */}
       <div className="simple-tile mb-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 rounded-lg border border-slate-600">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+            <div className="p-2 sm:p-3 rounded-lg border border-slate-600 flex-shrink-0">
               {getIconComponent(selectedCategory.icon)}
             </div>
-            <div>
-              <h1 className="text-3xl font-bold text-slate-100">
+            <div className="min-w-0">
+              <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-slate-100 break-words">
                 {selectedCategory.name}
               </h1>
-              <p className="text-slate-400 mt-1">
+              <p className="text-slate-400 mt-1 text-sm sm:text-base break-words">
                 {selectedCategory.description}
               </p>
               <div className="flex items-center gap-4 mt-2 text-sm text-slate-500">
-                <span>{selectedCategory.threadCount} {t('forum.threads')}</span>
+                <span className="whitespace-nowrap">{selectedCategory.threadCount} {t('forum.threads')}</span>
               </div>
             </div>
           </div>
@@ -150,10 +150,10 @@ const ForumCategoryPage: React.FC = () => {
           {isAuthenticated && (
             <Link
               to={`/forum/category/${categoryId}/new-thread`}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+              className="flex items-center justify-center gap-2 px-3 sm:px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm sm:text-base whitespace-nowrap"
             >
-              <Plus className="w-4 h-4" />
-                              <span>{t('forum.newThread')}</span>
+              <Plus className="w-4 h-4 flex-shrink-0" />
+              <span>{t('forum.newThread')}</span>
             </Link>
           )}
         </div>
@@ -187,71 +187,78 @@ const ForumCategoryPage: React.FC = () => {
               to={`/forum/thread/${thread.id}`}
               className="simple-tile block hover:border-blue-500/50 transition-all"
             >
-              <div className="flex items-center gap-4">
-                {/* Thread Icons */}
-                <div className="flex items-center gap-1">
-                  {thread.isPinned && (
-                    <Pin className="w-4 h-4 text-yellow-400" />
-                  )}
-                  {thread.isLocked ? (
-                    <Lock className="w-4 h-4 text-red-400" />
-                  ) : (
-                    <MessageSquare className="w-4 h-4 text-slate-400" />
-                  )}
-                </div>
-
-                {/* Thread Info */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <h3 className="font-semibold text-slate-100 truncate">
-                      {thread.title}
-                    </h3>
+              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+                <div className="flex items-start gap-3 flex-1 min-w-0">
+                  {/* Thread Icons */}
+                  <div className="flex items-center gap-1 flex-shrink-0 pt-1">
                     {thread.isPinned && (
-                      <span className="px-2 py-1 bg-yellow-600/20 text-yellow-400 text-xs rounded-full">
-                        Angepinnt
-                      </span>
+                      <Pin className="w-4 h-4 text-yellow-400" />
                     )}
-                    {thread.isLocked && (
-                      <span className="px-2 py-1 bg-red-600/20 text-red-400 text-xs rounded-full">
-                        Geschlossen
-                      </span>
+                    {thread.isLocked ? (
+                      <Lock className="w-4 h-4 text-red-400" />
+                    ) : (
+                      <MessageSquare className="w-4 h-4 text-slate-400" />
                     )}
                   </div>
-                  <div className="flex items-center gap-4 text-sm text-slate-400">
-                    <div className="flex items-center gap-1">
-                      <User className="w-3 h-3" />
-                      <span>{thread.authorName}</span>
+
+                  {/* Thread Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 mb-1">
+                      <h3 className="font-semibold text-slate-100 break-words text-sm sm:text-base">
+                        {thread.title}
+                      </h3>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        {thread.isPinned && (
+                          <span className="px-2 py-1 bg-yellow-600/20 text-yellow-400 text-xs rounded-full whitespace-nowrap">
+                            Angepinnt
+                          </span>
+                        )}
+                        {thread.isLocked && (
+                          <span className="px-2 py-1 bg-red-600/20 text-red-400 text-xs rounded-full whitespace-nowrap">
+                            Geschlossen
+                          </span>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex items-center gap-1">
-                      <Clock className="w-3 h-3" />
-                      <span>{formatDate(thread.createdAt)}</span>
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-xs sm:text-sm text-slate-400">
+                      <div className="flex items-center gap-1">
+                        <User className="w-3 h-3 flex-shrink-0" />
+                        <span className="break-words">{thread.authorName}</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <Clock className="w-3 h-3 flex-shrink-0" />
+                        <span className="whitespace-nowrap">{formatDate(thread.createdAt)}</span>
+                      </div>
                     </div>
                   </div>
                 </div>
 
-                {/* Thread Stats */}
-                <div className="flex items-center gap-6 text-sm">
-                  <div className="flex items-center gap-1 text-white">
-                    <MessageSquare className="w-4 h-4 text-white" />
-                    <span>{thread.postCount}</span>
+                {/* Thread Stats & Last Post */}
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6">
+                  {/* Thread Stats */}
+                  <div className="flex items-center gap-4 text-xs sm:text-sm">
+                    <div className="flex items-center gap-1 text-white">
+                      <MessageSquare className="w-4 h-4 text-white flex-shrink-0" />
+                      <span className="whitespace-nowrap">{thread.postCount}</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-white">
+                      <Eye className="w-4 h-4 text-white flex-shrink-0" />
+                      <span className="whitespace-nowrap">{thread.views}</span>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-1 text-white">
-                    <Eye className="w-4 h-4 text-white" />
-                    <span>{thread.views}</span>
-                  </div>
-                </div>
 
-                {/* Last Post */}
-                {thread.lastPost && (
-                  <div className="text-right text-sm text-slate-400 min-w-0">
-                    <div className="truncate">
-                      {t('forum.createdBy')} {thread.lastPost.authorName}
+                  {/* Last Post */}
+                  {thread.lastPost && (
+                    <div className="text-left sm:text-right text-xs sm:text-sm text-slate-400 min-w-0">
+                      <div className="break-words sm:truncate">
+                        {t('forum.createdBy')} {thread.lastPost.authorName}
+                      </div>
+                      <div className="text-xs whitespace-nowrap">
+                        {formatDate(thread.lastPost.createdAt)}
+                      </div>
                     </div>
-                    <div className="text-xs">
-                      {formatDate(thread.lastPost.createdAt)}
-                    </div>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </Link>
           ))}

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -146,44 +146,46 @@ const ForumThreadPage: React.FC = () => {
       <div className="mb-6">
         <Link 
           to="/forum" 
-          className="inline-flex items-center gap-2 text-slate-400 hover:text-slate-200 transition-colors"
+          className="inline-flex items-center gap-2 text-slate-400 hover:text-slate-200 transition-colors py-2 px-1 -mx-1 rounded-lg hover:bg-slate-700/50 min-h-[44px]"
         >
-          <ArrowLeft className="w-4 h-4" />
-{t('common.back')} {t('forum.backToCategory')} Forum
+          <ArrowLeft className="w-4 h-4 flex-shrink-0" />
+          <span className="text-sm sm:text-base break-words">{t('common.back')} {t('forum.backToCategory')} Forum</span>
         </Link>
       </div>
 
       {/* Thread Header */}
       <div className="simple-tile mb-6">
-        <div className="flex items-start justify-between mb-4">
+        <div className="mb-4">
           <div className="flex-1">
-            <div className="flex items-center gap-2 mb-2">
+            <div className="flex items-center gap-2 mb-2 flex-wrap">
               {selectedThread.isPinned && (
-                <Pin className="w-4 h-4 text-yellow-400" />
+                <Pin className="w-4 h-4 text-yellow-400 flex-shrink-0" />
               )}
               {selectedThread.isLocked && (
-                <Lock className="w-4 h-4 text-red-400" />
+                <Lock className="w-4 h-4 text-red-400 flex-shrink-0" />
               )}
-              <h1 className="text-2xl font-bold text-slate-100">
+              <h1 className="text-xl sm:text-2xl font-bold text-slate-100 break-words">
                 {selectedThread.title}
               </h1>
             </div>
-            <div className="flex items-center gap-4 text-sm text-white">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 text-sm text-white">
               <div className="flex items-center gap-1">
-                <User className="w-4 h-4 text-white" />
-                <span>{t('forum.createdBy')} {selectedThread.authorName}</span>
+                <User className="w-4 h-4 text-white flex-shrink-0" />
+                <span className="break-words">{t('forum.createdBy')} {selectedThread.authorName}</span>
               </div>
               <div className="flex items-center gap-1">
-                <Clock className="w-4 h-4 text-white" />
-                <span>{formatDate(selectedThread.createdAt)}</span>
+                <Clock className="w-4 h-4 text-white flex-shrink-0" />
+                <span className="whitespace-nowrap">{formatDate(selectedThread.createdAt)}</span>
               </div>
-              <div className="flex items-center gap-1">
-                <Eye className="w-4 h-4 text-white" />
-                <span>{selectedThread.views} Aufrufe</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <MessageSquare className="w-4 h-4 text-white" />
-                <span>{selectedThread.postCount} Beiträge</span>
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-1">
+                  <Eye className="w-4 h-4 text-white flex-shrink-0" />
+                  <span className="whitespace-nowrap">{selectedThread.views} Aufrufe</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <MessageSquare className="w-4 h-4 text-white flex-shrink-0" />
+                  <span className="whitespace-nowrap">{selectedThread.postCount} Beiträge</span>
+                </div>
               </div>
             </div>
           </div>
@@ -194,42 +196,42 @@ const ForumThreadPage: React.FC = () => {
       <div className="space-y-4 mb-6">
         {threadPosts.map((post, index) => (
           <div key={post.id} className="simple-tile">
-            <div className="flex gap-4">
+            <div className="flex gap-3 sm:gap-4">
               {/* User Avatar */}
               <div className="flex-shrink-0">
-                <div className="w-12 h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-full flex items-center justify-center text-lg">
+                <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-full flex items-center justify-center text-base sm:text-lg">
                   🎮
                 </div>
               </div>
 
               {/* Post Content */}
-              <div className="flex-1">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold text-slate-100">
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-2 gap-1 sm:gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-semibold text-slate-100 break-words">
                       {post.authorName}
                     </span>
                     {index === 0 && (
-                      <span className="px-2 py-1 bg-blue-600/20 text-blue-400 text-xs rounded-full">
+                      <span className="px-2 py-1 bg-blue-600/20 text-blue-400 text-xs rounded-full whitespace-nowrap">
                         Ersteller
                       </span>
                     )}
                   </div>
-                  <div className="flex items-center gap-2 text-sm text-slate-400">
-                    <span>#{index + 1}</span>
-                    <span>•</span>
-                    <span>{formatDate(post.createdAt)}</span>
+                  <div className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm text-slate-400 flex-wrap">
+                    <span className="whitespace-nowrap">#{index + 1}</span>
+                    <span className="hidden sm:inline">•</span>
+                    <span className="whitespace-nowrap">{formatDate(post.createdAt)}</span>
                     {post.isEdited && (
                       <>
-                        <span>•</span>
-                        <span className="text-yellow-400">{t('forum.edited')}</span>
+                        <span className="hidden sm:inline">•</span>
+                        <span className="text-yellow-400 whitespace-nowrap">{t('forum.edited')}</span>
                       </>
                     )}
                   </div>
                 </div>
 
                 {/* Post Content */}
-                <div className="text-slate-200 mb-3 whitespace-pre-wrap">
+                <div className="text-slate-200 mb-3 whitespace-pre-wrap break-words overflow-wrap-anywhere">
                   {post.content}
                 </div>
 
@@ -263,11 +265,11 @@ const ForumThreadPage: React.FC = () => {
           ) : (
             <form onSubmit={handleSubmitReply}>
               <div className="flex items-center gap-3 mb-4">
-                <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-purple-600 rounded-full flex items-center justify-center">
+                <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-purple-600 rounded-full flex items-center justify-center flex-shrink-0">
                   {user?.avatar || '🎮'}
                 </div>
-                <div>
-                  <div className="font-semibold text-slate-100">{user?.username}</div>
+                <div className="min-w-0">
+                  <div className="font-semibold text-slate-100 break-words">{user?.username}</div>
                   <div className="text-sm text-slate-400">{t('forum.replyWrite')}</div>
                 </div>
               </div>
@@ -276,7 +278,7 @@ const ForumThreadPage: React.FC = () => {
                 value={replyContent}
                 onChange={(e) => setReplyContent(e.target.value)}
                 placeholder={t('placeholder.replyContent')}
-                className="w-full h-32 p-3 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                className="w-full h-32 p-3 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none text-sm sm:text-base"
                 maxLength={2000}
                 required
               />
@@ -296,15 +298,15 @@ const ForumThreadPage: React.FC = () => {
                 />
               </div>
 
-              <div className="flex items-center justify-between mt-4">
-                <div className="text-sm text-slate-400">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-4">
+                <div className="text-sm text-slate-400 order-2 sm:order-1">
                   {replyContent.length}/2000 Zeichen
                 </div>
-                <div className="flex gap-2">
+                <div className="flex gap-2 order-1 sm:order-2">
                   <button
                     type="button"
                     onClick={resetReplyForm}
-                    className="px-4 py-2 text-slate-400 hover:text-slate-200 transition-colors"
+                    className="px-3 sm:px-4 py-2 text-slate-400 hover:text-slate-200 transition-colors text-sm sm:text-base"
                     disabled={isSubmitting}
                   >
                     Abbrechen
@@ -312,14 +314,14 @@ const ForumThreadPage: React.FC = () => {
                   <button
                     type="submit"
                     disabled={!replyContent.trim() || isSubmitting}
-                    className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-600 text-white rounded-lg transition-colors"
+                    className="flex items-center gap-2 px-3 sm:px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-600 text-white rounded-lg transition-colors text-sm sm:text-base"
                   >
                     {isSubmitting ? (
                       <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
                     ) : (
                       <Send className="w-4 h-4" />
                     )}
-                    <span>{isSubmitting ? 'Wird gesendet...' : 'Antworten'}</span>
+                    <span className="whitespace-nowrap">{isSubmitting ? 'Wird gesendet...' : 'Antworten'}</span>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
Improve forum component mobile responsiveness to prevent content overflow on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-32fb7036-03e7-40ee-920d-82a7ceeb57a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32fb7036-03e7-40ee-920d-82a7ceeb57a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>