### PR TITLE
Standardize and enlarge card meta symbols

### DIFF
--- a/src/components/EventFeedWidget.tsx
+++ b/src/components/EventFeedWidget.tsx
@@ -336,13 +336,13 @@ const EventCard: React.FC<EventCardProps> = ({ event, leaderboard, timeRemaining
                     </div>
                     <div className="flex items-center justify-center gap-1">
                       {entry.verified && (
-                        <div className="w-2 h-2 bg-green-400 rounded-full" title={t('home.verified')}></div>
+                        <div className="w-3 h-3 bg-green-400 rounded-full" title={t('home.verified')}></div>
                       )}
                       {entry.mediaUrl && (
                         <div className="flex items-center" title={`${entry.documentationType === 'photo' ? 'Photo' : entry.documentationType === 'video' ? 'Video' : 'Livestream'} available`}>
-                          {entry.documentationType === 'photo' && <Camera className="w-3 h-3 text-slate-400" />}
-                          {entry.documentationType === 'video' && <Video className="w-3 h-3 text-slate-400" />}
-                          {entry.documentationType === 'livestream' && <Radio className="w-3 h-3 text-slate-400" />}
+                          {entry.documentationType === 'photo' && <Camera className="w-4 h-4 text-slate-400" />}
+                          {entry.documentationType === 'video' && <Video className="w-4 h-4 text-slate-400" />}
+                          {entry.documentationType === 'livestream' && <Radio className="w-4 h-4 text-slate-400" />}
                         </div>
                       )}
                     </div>

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Newspaper, X } from 'lucide-react'
+import { Newspaper, X, Calendar, Tag } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
 import { InteractionBar } from './InteractionComponents'
@@ -133,6 +133,16 @@ const NewsCard: React.FC<NewsCardProps> = ({ newsItem, index, onDismiss, isAnima
           <span className={`capitalize ${getTypeColor(newsItem.type)}`}>
             {getTypeTranslation(newsItem.type)}
           </span>
+        </div>
+      </div>
+      
+      {/* Meta symbols in corner */}
+      <div className="absolute bottom-3 right-3 flex items-center gap-1">
+        <div className={`${getTypeColor(newsItem.type)}`} title={getTypeTranslation(newsItem.type)}>
+          <Tag className="w-4 h-4" />
+        </div>
+        <div className="text-slate-400" title={formatTime(newsItem.date)}>
+          <Calendar className="w-4 h-4" />
         </div>
       </div>
       

--- a/src/components/SingleFanArtCard.tsx
+++ b/src/components/SingleFanArtCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react'
-import { Palette, Heart, Eye } from 'lucide-react'
+import { Palette, Heart, Eye, Image, Calendar } from 'lucide-react'
 import { useLanguage } from '../contexts/LanguageContext'
 import { useUser } from '../contexts/UserContext'
 import { useNavigate } from 'react-router-dom'
@@ -119,6 +119,18 @@ const SingleFanArtCard: React.FC<SingleFanArtCardProps> = ({ fanArtItems, classN
         <div className="text-xs text-slate-400">
           <span className="text-rose-400">{item.game}</span>
         </div>
+      </div>
+      
+      {/* Meta symbols in corner */}
+      <div className="absolute bottom-3 right-3 flex items-center gap-1">
+        <div className="text-slate-400" title="Fan Art">
+          <Image className="w-4 h-4" />
+        </div>
+        {item.createdAt && (
+          <div className="text-slate-400" title={item.createdAt.toLocaleDateString()}>
+            <Calendar className="w-4 h-4" />
+          </div>
+        )}
       </div>
       
       <div className="swipeable-card-content">

--- a/src/components/SingleForumCard.tsx
+++ b/src/components/SingleForumCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import { MessageCircle } from 'lucide-react'
+import { MessageCircle, Users, Clock } from 'lucide-react'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
 import { useNavigate } from 'react-router-dom'
 import { InteractionBar } from './InteractionComponents'
@@ -102,6 +102,16 @@ const SingleForumCard: React.FC<SingleForumCardProps> = ({ forumThreads, classNa
         </div>
         <div className="text-xs text-slate-400">
           <span className="capitalize text-cyan-400">{thread.category}</span>
+        </div>
+      </div>
+      
+      {/* Meta symbols in corner */}
+      <div className="absolute bottom-3 right-3 flex items-center gap-1">
+        <div className="text-slate-400" title={`${thread.replies} Antworten`}>
+          <Users className="w-4 h-4" />
+        </div>
+        <div className="text-slate-400" title={formatTime(thread.lastActivity)}>
+          <Clock className="w-4 h-4" />
         </div>
       </div>
       

--- a/src/components/SingleMarketplaceCard.tsx
+++ b/src/components/SingleMarketplaceCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import { ShoppingBag } from 'lucide-react'
+import { ShoppingBag, Star, Package } from 'lucide-react'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
 import { useNavigate } from 'react-router-dom'
 
@@ -232,7 +232,7 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
             }`}
             onClick={() => handleCardClick(currentItem)}
           >
-            <div className="swipeable-card bg-gradient-to-br from-purple-600/20 to-purple-800/20 border-l-4 border-accent-purple">
+            <div className="swipeable-card bg-gradient-to-br from-purple-600/20 to-purple-800/20 border-l-4 border-accent-purple relative">
               <div className="swipeable-card-header">
                 <div className="flex items-center gap-2">
                   <ShoppingBag className="w-5 h-5 text-accent-purple" />
@@ -240,6 +240,16 @@ const SingleMarketplaceCard: React.FC<SingleMarketplaceCardProps> = ({ marketpla
                 </div>
                 <div className="text-xs text-text-muted">
                   {currentItem.category}
+                </div>
+              </div>
+              
+              {/* Meta symbols in corner */}
+              <div className="absolute bottom-3 right-3 flex items-center gap-1">
+                <div className="text-slate-400" title={currentItem.condition}>
+                  <Package className="w-4 h-4" />
+                </div>
+                <div className="text-slate-400" title={currentItem.seller}>
+                  <Star className="w-4 h-4" />
                 </div>
               </div>
               <div className="swipeable-card-content">

--- a/src/components/SingleMediaCard.tsx
+++ b/src/components/SingleMediaCard.tsx
@@ -260,7 +260,7 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                 : 'transform translate-x-0 opacity-100'
             }`}
           >
-            <div className="swipeable-card bg-gradient-to-br from-green-600/20 to-green-800/20 border-l-4 border-accent-green">
+            <div className="swipeable-card bg-gradient-to-br from-green-600/20 to-green-800/20 border-l-4 border-accent-green relative">
               <div className="swipeable-card-header">
                 <div className="flex items-center gap-2">
                   <Play className="w-5 h-5 text-accent-green" />
@@ -270,6 +270,16 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                   <span className={getTypeColor(currentItem.type)}>
                     {getTypeTranslation(currentItem.type)}
                   </span>
+                </div>
+              </div>
+              
+              {/* Meta symbols in corner */}
+              <div className="absolute bottom-3 right-3 flex items-center gap-1">
+                {currentItem.verified && (
+                  <div className="w-4 h-4 bg-green-400 rounded-full" title={t('card.verified')}></div>
+                )}
+                <div className={`${getTypeColor(currentItem.type)}`} title={getTypeTranslation(currentItem.type)}>
+                  {getTypeIcon(currentItem.type)}
                 </div>
               </div>
               <div className="swipeable-card-content">
@@ -294,17 +304,7 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                   <div className="border-t border-slate-600/30 pt-3 mt-auto">
                     <div className="flex items-center justify-between text-sm text-text-muted">
                       <span>{currentItem.uploader}</span>
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium">{formatTime(currentItem.date)}</span>
-                        <div className="flex items-center gap-1">
-                          {currentItem.verified && (
-                            <div className="w-4 h-4 bg-green-400 rounded-full" title={t('card.verified')}></div>
-                          )}
-                          <div className={`flex items-center ${getTypeColor(currentItem.type)}`} title={getTypeTranslation(currentItem.type)}>
-                            {getTypeIcon(currentItem.type)}
-                          </div>
-                        </div>
-                      </div>
+                      <span className="font-medium">{formatTime(currentItem.date)}</span>
                     </div>
                   </div>
                 </div>

--- a/src/components/SingleMediaCard.tsx
+++ b/src/components/SingleMediaCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import { Play } from 'lucide-react'
+import { Play, Camera, Video, Trophy, Radio } from 'lucide-react'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
 import { InteractionBar } from './InteractionComponents'
 
@@ -104,15 +104,15 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
   const getTypeIcon = (type: string) => {
     switch (type) {
       case 'speedrun':
-        return '🏃'
+        return <Play className="w-4 h-4" />
       case 'screenshot':
-        return '📸'
+        return <Camera className="w-4 h-4" />
       case 'achievement':
-        return '🏆'
+        return <Trophy className="w-4 h-4" />
       case 'stream':
-        return '📺'
+        return <Radio className="w-4 h-4" />
       default:
-        return '🎮'
+        return <Video className="w-4 h-4" />
     }
   }
 
@@ -171,13 +171,10 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                       <Play className="w-5 h-5 text-accent-green" />
                       <h3 className="text-responsive-base font-bold text-text-primary">{t('card.media')}</h3>
                     </div>
-                    <div className="text-xs text-text-muted flex items-center gap-1">
+                    <div className="text-xs text-text-muted">
                       <span className={getTypeColor(mediaItems[currentIndex + 1].type)}>
-                        {getTypeIcon(mediaItems[currentIndex + 1].type)} {getTypeTranslation(mediaItems[currentIndex + 1].type)}
+                        {getTypeTranslation(mediaItems[currentIndex + 1].type)}
                       </span>
-                      {mediaItems[currentIndex + 1].verified && (
-                        <span className="text-accent-green">✓ {t('card.verified')}</span>
-                      )}
                     </div>
                   </div>
                   <div className="swipeable-card-content">
@@ -216,13 +213,10 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                       <Play className="w-5 h-5 text-accent-green" />
                       <h3 className="text-responsive-base font-bold text-text-primary">{t('card.media')}</h3>
                     </div>
-                    <div className="text-xs text-text-muted flex items-center gap-1">
+                    <div className="text-xs text-text-muted">
                       <span className={getTypeColor(mediaItems[currentIndex - 1].type)}>
-                        {getTypeIcon(mediaItems[currentIndex - 1].type)} {getTypeTranslation(mediaItems[currentIndex - 1].type)}
+                        {getTypeTranslation(mediaItems[currentIndex - 1].type)}
                       </span>
-                      {mediaItems[currentIndex - 1].verified && (
-                        <span className="text-accent-green">✓ {t('card.verified')}</span>
-                      )}
                     </div>
                   </div>
                   <div className="swipeable-card-content">
@@ -272,13 +266,10 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                   <Play className="w-5 h-5 text-accent-green" />
                   <h3 className="text-responsive-base font-bold text-text-primary">{t('card.media')}</h3>
                 </div>
-                <div className="text-xs text-text-muted flex items-center gap-1">
+                <div className="text-xs text-text-muted">
                   <span className={getTypeColor(currentItem.type)}>
-                    {getTypeIcon(currentItem.type)} {getTypeTranslation(currentItem.type)}
+                    {getTypeTranslation(currentItem.type)}
                   </span>
-                  {currentItem.verified && (
-                    <span className="text-accent-green">✓ {t('card.verified')}</span>
-                  )}
                 </div>
               </div>
               <div className="swipeable-card-content">
@@ -303,7 +294,17 @@ const SingleMediaCard: React.FC<SingleMediaCardProps> = ({ mediaItems, className
                   <div className="border-t border-slate-600/30 pt-3 mt-auto">
                     <div className="flex items-center justify-between text-sm text-text-muted">
                       <span>{currentItem.uploader}</span>
-                      <span className="font-medium">{formatTime(currentItem.date)}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{formatTime(currentItem.date)}</span>
+                        <div className="flex items-center gap-1">
+                          {currentItem.verified && (
+                            <div className="w-4 h-4 bg-green-400 rounded-full" title={t('card.verified')}></div>
+                          )}
+                          <div className={`flex items-center ${getTypeColor(currentItem.type)}`} title={getTypeTranslation(currentItem.type)}>
+                            {getTypeIcon(currentItem.type)}
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/components/SingleNewsCard.tsx
+++ b/src/components/SingleNewsCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import { Newspaper } from 'lucide-react'
+import { Newspaper, Calendar, Tag } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import NewsCard from './NewsCard'
 import { useLanguage } from '../contexts/LanguageContext'

--- a/src/components/SingleRecordCard.tsx
+++ b/src/components/SingleRecordCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import { Trophy } from 'lucide-react'
+import { Trophy, Monitor, Gamepad2 } from 'lucide-react'
 import { useLanguage, getLocaleString } from '../contexts/LanguageContext'
 
 interface PersonalRecord {
@@ -122,10 +122,8 @@ const SingleRecordCard: React.FC<SingleRecordCardProps> = ({ personalRecords, cl
                       <Trophy className="w-5 h-5 text-accent-yellow" />
                       <h3 className="text-responsive-base font-bold text-text-primary">{t('card.records')}</h3>
                     </div>
-                    <div className="text-xs text-text-muted flex items-center gap-1">
-                      {personalRecords[currentIndex + 1].verified && (
-                        <span className="text-accent-green">✓ {t('card.verified')}</span>
-                      )}
+                    <div className="text-xs text-text-muted">
+                      <span>{personalRecords[currentIndex + 1].platform}</span>
                     </div>
                   </div>
                   <div className="swipeable-card-content">
@@ -158,10 +156,8 @@ const SingleRecordCard: React.FC<SingleRecordCardProps> = ({ personalRecords, cl
                       <Trophy className="w-5 h-5 text-accent-yellow" />
                       <h3 className="text-responsive-base font-bold text-text-primary">{t('card.records')}</h3>
                     </div>
-                    <div className="text-xs text-text-muted flex items-center gap-1">
-                      {personalRecords[currentIndex - 1].verified && (
-                        <span className="text-accent-green">✓ {t('card.verified')}</span>
-                      )}
+                    <div className="text-xs text-text-muted">
+                      <span>{personalRecords[currentIndex - 1].platform}</span>
                     </div>
                   </div>
                   <div className="swipeable-card-content">
@@ -199,16 +195,27 @@ const SingleRecordCard: React.FC<SingleRecordCardProps> = ({ personalRecords, cl
                 : 'transform translate-x-0 opacity-100'
             }`}
           >
-            <div className="swipeable-card bg-gradient-to-br from-yellow-600/20 to-yellow-800/20 border-l-4 border-accent-yellow">
+            <div className="swipeable-card bg-gradient-to-br from-yellow-600/20 to-yellow-800/20 border-l-4 border-accent-yellow relative">
               <div className="swipeable-card-header">
                 <div className="flex items-center gap-2">
                   <Trophy className="w-5 h-5 text-accent-yellow" />
                   <h3 className="text-responsive-base font-bold text-text-primary">{t('card.records')}</h3>
                 </div>
-                <div className="text-xs text-text-muted flex items-center gap-1">
-                  {currentRecord.verified && (
-                    <span className="text-accent-green">✓ {t('card.verified')}</span>
-                  )}
+                <div className="text-xs text-text-muted">
+                  <span>{currentRecord.platform}</span>
+                </div>
+              </div>
+              
+              {/* Meta symbols in corner */}
+              <div className="absolute bottom-3 right-3 flex items-center gap-1">
+                {currentRecord.verified && (
+                  <div className="w-4 h-4 bg-green-400 rounded-full" title={t('card.verified')}></div>
+                )}
+                <div className="text-slate-400" title={currentRecord.platform}>
+                  {currentRecord.platform.toLowerCase().includes('pc') || currentRecord.platform.toLowerCase().includes('computer') ? 
+                    <Monitor className="w-4 h-4" /> : 
+                    <Gamepad2 className="w-4 h-4" />
+                  }
                 </div>
               </div>
               <div className="swipeable-card-content">


### PR DESCRIPTION
Unify meta symbols across all card types to match event card styling and increase their size for better visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-295fa64e-a720-431c-991a-ee8b0a6b5fc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-295fa64e-a720-431c-991a-ee8b0a6b5fc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>