### PR TITLE
Add battle map feature to homescreen retro

### DIFF
--- a/src/components/HomeScreenRetro.tsx
+++ b/src/components/HomeScreenRetro.tsx
@@ -14,7 +14,8 @@ import {
   MessageCircle,
   Palette,
   Newspaper,
-  BarChart3
+  BarChart3,
+  MapPin
 } from 'lucide-react'
 
 const HomeScreenRetro: React.FC = () => {
@@ -69,6 +70,17 @@ const HomeScreenRetro: React.FC = () => {
           <div className="simple-tile-label">
             <div className="font-medium text-text-primary text-sm">{t('nav.events')}</div>
             <div className="text-xs text-text-muted">{t('home.events.subtitle')}</div>
+          </div>
+        </Link>
+
+        {/* Battle64 Map Tile */}
+        <Link to="/map" className="simple-tile simple-tile-small mobile-tile-optimized">
+          <div className="simple-tile-icon">
+            <MapPin className="w-7 h-7 text-yellow-400 mx-auto" />
+          </div>
+          <div className="simple-tile-label">
+            <div className="font-medium text-text-primary text-sm">{t('nav.map')}</div>
+            <div className="text-xs text-text-muted">{t('home.map.subtitle')}</div>
           </div>
         </Link>
 


### PR DESCRIPTION
Adds the Battle64 Map tile to the HomeScreenRetro component as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc21aa3e-f376-4b8a-9396-d3208e1a0905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc21aa3e-f376-4b8a-9396-d3208e1a0905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

