### PR TITLE
Fix forwardRef undefined error in icons vendor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/leaflet.markercluster": "^1.5.5",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
-        "lucide-react": "^0.536.0",
+        "lucide-react": "^0.539.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-leaflet": "^5.0.0",
@@ -6299,9 +6299,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.536.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
-      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "version": "0.539.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.539.0.tgz",
+      "integrity": "sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/leaflet.markercluster": "^1.5.5",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
-    "lucide-react": "^0.536.0",
+    "lucide-react": "^0.539.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-leaflet": "^5.0.0",


### PR DESCRIPTION
Update `lucide-react` to resolve `forwardRef` compatibility issues with React 19.

The `TypeError: Cannot read properties of undefined (reading forwardRef)` occurred because React 19 deprecated `forwardRef`, but the previously installed `lucide-react` version (0.536.0) still relied on it. Updating to `lucide-react` 0.539.0 resolves this by using a version compatible with React 19's changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bca50e3-99ab-485a-a52b-6fc342352c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4bca50e3-99ab-485a-a52b-6fc342352c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

