### PR TITLE
Fix main page and favicon errors

### DIFF
--- a/public/n64-icon.svg
+++ b/public/n64-icon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="controllerGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#4f46e5;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#3730a3;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Controller body -->
+  <path d="M8 20 C8 16, 12 12, 16 12 L48 12 C52 12, 56 16, 56 20 L56 36 C56 40, 52 44, 48 44 L16 44 C12 44, 8 40, 8 36 Z" fill="url(#controllerGradient)" stroke="#1e1b4b" stroke-width="1"/>
+  
+  <!-- Left grip -->
+  <path d="M8 28 C4 28, 2 32, 2 36 L2 48 C2 52, 6 56, 10 56 C14 56, 18 52, 18 48 L18 36 C18 32, 14 28, 10 28 Z" fill="url(#controllerGradient)" stroke="#1e1b4b" stroke-width="1"/>
+  
+  <!-- Right grip -->
+  <path d="M56 28 C60 28, 62 32, 62 36 L62 48 C62 52, 58 56, 54 56 C50 56, 46 52, 46 48 L46 36 C46 32, 50 28, 54 28 Z" fill="url(#controllerGradient)" stroke="#1e1b4b" stroke-width="1"/>
+  
+  <!-- Center stick -->
+  <circle cx="32" cy="28" r="6" fill="#6366f1" stroke="#1e1b4b" stroke-width="1"/>
+  <circle cx="32" cy="28" r="3" fill="#8b5cf6"/>
+  
+  <!-- D-pad -->
+  <rect x="16" y="26" width="8" height="2" rx="1" fill="#6366f1"/>
+  <rect x="19" y="23" width="2" height="8" rx="1" fill="#6366f1"/>
+  
+  <!-- Action buttons -->
+  <circle cx="44" cy="24" r="2" fill="#fbbf24"/>
+  <circle cx="48" cy="28" r="2" fill="#10b981"/>
+  <circle cx="44" cy="32" r="2" fill="#ef4444"/>
+  <circle cx="40" cy="28" r="2" fill="#3b82f6"/>
+  
+  <!-- Text -->
+  <text x="32" y="52" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" font-weight="bold" fill="#1e1b4b">N64</text>
+</svg>

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,11 @@
     { "source": "/splash/:path*", "destination": "/splash/:path*" },
     { "source": "/manifest.json", "destination": "/manifest.json" },
     { "source": "/sw.js", "destination": "/sw.js" },
-    { "source": "/:path*", "destination": "/index" }
+    { "source": "/favicon.ico", "destination": "/favicon.ico" },
+    { "source": "/favicon-16x16.png", "destination": "/favicon-16x16.png" },
+    { "source": "/favicon-32x32.png", "destination": "/favicon-32x32.png" },
+    { "source": "/n64-icon.svg", "destination": "/n64-icon.svg" },
+    { "source": "/:path*", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Fixes Vercel 404 errors for the main page and favicons by correcting `vercel.json` rewrites and adding a missing icon.

The main page was not found because the Vercel rewrite rule for the SPA fallback incorrectly pointed to `/index` instead of `/index.html`. Favicons were also not found as they were not explicitly routed in `vercel.json`, and a referenced `n64-icon.svg` was missing. This PR corrects the main page rewrite, adds explicit routes for all favicons, and creates the missing `n64-icon.svg`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4950e617-0fe9-4972-b507-2d40ec70b3cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4950e617-0fe9-4972-b507-2d40ec70b3cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

