### PR TITLE
Handle unauthorized manifest fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
     
+    <!-- PWA Manifest -->
+    <link rel="manifest" href="/manifest.webmanifest" />
+    
     <!-- Favicon and App Icons -->
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" type="image/svg+xml" href="/n64-icon.svg" />

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,139 @@
+{
+  "name": "Battle64 - N64 Community",
+  "short_name": "Battle64",
+  "description": "Die ultimative Nintendo 64 Community mit Events, Ranglisten, Sammler-Features und mehr",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#1e293b",
+  "orientation": "any",
+  "scope": "/",
+  "lang": "de",
+  "dir": "ltr",
+  "categories": ["games", "entertainment", "social"],
+  "icons": [
+    {
+      "src": "/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Events",
+      "short_name": "Events",
+      "description": "Aktuelle N64 Events und Turniere",
+      "url": "/events",
+      "icons": [
+        {
+          "src": "/icons/events-96x96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Rangliste",
+      "short_name": "Rangliste",
+      "description": "Community Ranglisten und Bestzeiten",
+      "url": "/leaderboard",
+      "icons": [
+        {
+          "src": "/icons/leaderboard-96x96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Sammler",
+      "short_name": "Sammler",
+      "description": "N64 Spiele sammeln und verwalten",
+      "url": "/collector",
+      "icons": [
+        {
+          "src": "/icons/collector-96x96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Forum",
+      "short_name": "Forum",
+      "description": "Community Diskussionen",
+      "url": "/forum",
+      "icons": [
+        {
+          "src": "/icons/forum-96x96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "/screenshots/desktop-home.png",
+      "sizes": "1280x720",
+      "type": "image/png",
+      "form_factor": "wide",
+      "label": "N64 Nexus Homepage auf Desktop"
+    },
+    {
+      "src": "/screenshots/mobile-home.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "N64 Nexus Homepage auf Mobile"
+    },
+    {
+      "src": "/screenshots/desktop-events.png",
+      "sizes": "1280x720",
+      "type": "image/png",
+      "form_factor": "wide",
+      "label": "Events Seite auf Desktop"
+    },
+    {
+      "src": "/screenshots/mobile-collector.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "Sammler Modus auf Mobile"
+    }
+  ],
+  "related_applications": [],
+  "prefer_related_applications": false,
+  "edge_side_panel": {
+    "preferred_width": 400
+  },
+  "handle_links": "preferred",
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  }
+}


### PR DESCRIPTION
Create `manifest.webmanifest` and link it in `index.html` to resolve 401 Unauthorized error for PWA manifest.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5213dcd-31ad-4f25-9ff6-cd67f4615552">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5213dcd-31ad-4f25-9ff6-cd67f4615552">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

